### PR TITLE
Fix NPE in Consumer

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/Converters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/Converters.scala
@@ -104,12 +104,13 @@ object Converters {
       self
         .asScala
         .toList
-        .traverse { case (k, v) =>
+        .collect { case (k, v) if k != null && v != null =>
           for {
             a <- ka(k)
             b <- vb(v)
           } yield (a, b)
         }
+        .sequence
         .map { _.toMap }
     }
   }

--- a/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/ConsumerSpec.scala
+++ b/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/ConsumerSpec.scala
@@ -173,12 +173,12 @@ class ConsumerSpec extends AnyWordSpec with Matchers {
     }
 
     "committed with nulls " in new Scope {
-      override val committedNull = true
+      override def committedNull = true
       consumer.committed(partitions) should produce(Map.empty[TopicPartition, OffsetAndMetadata])
     }
 
     "committed with timeout with nulls" in new Scope {
-      override val committedNull = true
+      override def committedNull = true
       consumer.committed(partitions, 1.second) should produce(Map.empty[TopicPartition, OffsetAndMetadata])
     }
 
@@ -290,7 +290,7 @@ class ConsumerSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    protected val committedNull = false
+    protected def committedNull = false
 
     val consumerJ = new ConsumerJ[Bytes, Bytes] {
 


### PR DESCRIPTION
`Map<TopicPartition,OffsetAndMetadata>` returned by `KafkaConsumer.committed` can contain null value if no offset was committed by this consumer group:
https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#committed-java.util.Set
> Returns:
>The latest committed offsets for the given partitions; null will be returned for the partition if there is no such message.

This causes SKafka `Consumer` to fail with NPE:
```
java.lang.NullPointerException: null
	at com.evolutiongaming.skafka.Converters$SkafkaOffsetAndMetadataJOps$.asScala$extension(Converters.scala:193)
	at com.evolutiongaming.skafka.consumer.Consumer$.$anonfun$apply$15(Consumer.scala:320)
	at com.evolutiongaming.skafka.Converters$MapJOps$.$anonfun$asScalaMap$2(Converters.scala:110)
```

I changed `Converters` so that it drops null values from the map.