### PR TITLE
update RebalanceListener1/RebalanceCallback docs

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceCallback.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceCallback.scala
@@ -45,7 +45,11 @@ import scala.util.{Failure, Success, Try}
   * {{{
   * new RebalanceListener1[IO] {
   *
+  *  // one way is to import all methods, and then do `seek(...)`/`position(...)`/etc
   *  import RebalanceCallback._
+  *
+  *  // or assign it to a `val` and write code like `consumer.commit(offsets)`
+  *  val consumer = RebalanceCallback
   *
   *  def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]) = {
   *    for {
@@ -57,7 +61,7 @@ import scala.util.{Failure, Success, Try}
   *  def onPartitionsRevoked(partitions: NonEmptySet[TopicPartition]) =
   *    for {
   *      offsets <- lift(committableOffsetsFor(partitions))
-  *      a       <- commit(offsets)
+  *      a       <- consumer.commit(offsets)
   *    } yield a
   *
   *  def onPartitionsLost(partitions: NonEmptySet[TopicPartition]) = empty

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1.scala
@@ -13,12 +13,16 @@ import com.evolutiongaming.skafka.TopicPartition
   *
   * Below is an example inspired by [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener]] documentation.
   *
-  * Compiling and working example is available [[https://github.com/evolution-gaming/skafka/blob/d2af038b012523533f2b73d432721d6d1e7cebbe/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1Spec.scala here]]:
-  * TODO: replace with shorter github link after merge of https://github.com/evolution-gaming/skafka/pull/122
+  * Compiling and working example is available [[https://github.com/evolution-gaming/skafka/blob/master/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1Spec.scala here]]
   * {{{
   *
   * class SaveOffsetsOnRebalance[F[_]: Applicative] extends RebalanceListener1[F] {
-  *  import RebalanceCallback._
+  *
+  *   // one way is to import all methods, and then do `seek(...)`/`position(...)`/etc
+  *   import RebalanceCallback._
+  *
+  *   // or assign it to a `val` and write code like `consumer.position(partition)`
+  *   val consumer = RebalanceCallback
   *
   *  def onPartitionsAssigned(partitions: NonEmptySet[TopicPartition]) =
   *    for {
@@ -32,7 +36,7 @@ import com.evolutiongaming.skafka.TopicPartition
   *      positions <- partitions.foldM(Map.empty[TopicPartition, Offset]) {
   *        case (offsets, partition) =>
   *          for {
-  *            position <- position(partition)
+  *            position <- consumer.position(partition)
   *          } yield offsets + (partition -> position)
   *      }
   *      // save the offsets in an external store using some custom code not described here

--- a/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1Spec.scala
+++ b/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/RebalanceListener1Spec.scala
@@ -82,7 +82,11 @@ object RebalanceListener1Spec {
    */
   class SaveOffsetsOnRebalance[F[_]: Applicative] extends RebalanceListener1[F] {
 
+    // one way is to import all methods, and then do `seek(...)`/`position(...)`/etc
     import RebalanceCallback._
+
+    // or assign it to a `val` and write code like `consumer.position(partition)`
+    val consumer = RebalanceCallback
 
     def onPartitionsAssigned(partitions: Nes[TopicPartition]) =
       for {
@@ -96,7 +100,7 @@ object RebalanceListener1Spec {
         positions <- partitions.foldM(Map.empty[TopicPartition, Offset]) {
           case (offsets, partition) =>
             for {
-              position <- position(partition)
+              position <- consumer.position(partition)
             } yield offsets + (partition -> position)
         }
         // save the offsets in an external store using some custom code not described here


### PR DESCRIPTION
This PR:
- Updates docs with alternative usage of `RebalanceCallback` which allows to write code like you're interacting with consumer: `consumer.commit(offsets)`
- resolves one TODO from docs about shorter github link to `RebalanceListener1Spec`

```
// one way is to import all methods, and then do `seek(...)`/`position(...)`/etc
import RebalanceCallback._

// or assign it to a `val` and write code like `consumer.commit(offsets)`
val consumer = RebalanceCallback
```