### PR TITLE
Add scalafix with OrganizeImports to the build

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,16 @@
+OrganizeImports {
+  blankLines = Auto
+  coalesceToWildcardImportThreshold = 5
+  expandRelative = false
+  groupExplicitlyImportedImplicitsSeparately = false
+  groupedImports = Merge
+  groups = [
+    "re:javax?\\."
+    "*"
+    "scala."
+  ]
+  importSelectorsOrder = Ascii
+  importsOrder = Ascii
+  preset = INTELLIJ_2020_3
+  removeUnused = true
+}

--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,13 @@ lazy val commonSettings = Seq(
   },
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolutiongaming.skafka.consumer.Consumer.subscribe"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.skafka.Converters#MapJOps.asScalaMap$extension")
-  )
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.evolutiongaming.skafka.Converters#MapJOps.asScalaMap$extension"
+    )
+  ),
+  semanticdbEnabled := true,
+  semanticdbVersion := scalafixSemanticdb.revision
 )
-
 
 lazy val root = (project
   in file(".")
@@ -35,27 +38,27 @@ lazy val root = (project
   settings (name := "skafka")
   settings commonSettings
   settings (publish / skip := true)
-  aggregate(skafka, `play-json`, tests))
+  aggregate (skafka, `play-json`, tests))
 
 lazy val skafka = (project
   in file("skafka")
   settings commonSettings
-  settings(                                                                          
-    name := "skafka",
-    scalacOptions -= "-Ywarn-unused:params",
-    libraryDependencies ++= Seq(
-      Cats.core,
-      Cats.effect,
-      `config-tools`,
-      Kafka.clients,
-      `future-helper`,
-      `cats-helper`,
-      smetrics,
-      scalatest % Test,
-      Cats.laws % Test,
-      discipline % Test,
-      `scala-java8-compat`,
-      `collection-compat`)))
+  settings (name := "skafka",
+  scalacOptions -= "-Ywarn-unused:params",
+  libraryDependencies ++= Seq(
+    Cats.core,
+    Cats.effect,
+    `config-tools`,
+    Kafka.clients,
+    `future-helper`,
+    `cats-helper`,
+    smetrics,
+    scalatest  % Test,
+    Cats.laws  % Test,
+    discipline % Test,
+    `scala-java8-compat`,
+    `collection-compat`
+  )))
 
 lazy val `play-json` = (project
   in file("modules/play-json")
@@ -68,16 +71,16 @@ lazy val tests = (project in file("tests")
   disablePlugins (MimaPlugin)
   settings (name := "skafka-tests")
   settings commonSettings
-  settings Seq(
-    publish / skip := true,
-    Test / fork := true,
-    Test / parallelExecution := false)
-    dependsOn skafka % "compile->compile;test->test"
-    settings (libraryDependencies ++= Seq(
-      Kafka.kafka % Test,
-      `kafka-launcher` % Test,
-      Slf4j.api % Test,
-      Slf4j.`log4j-over-slf4j` % Test,
-      Logback.core % Test,
-      Logback.classic % Test,
-      scalatest % Test)))
+  settings Seq(publish / skip := true, Test / fork := true, Test / parallelExecution := false)
+  dependsOn skafka % "compile->compile;test->test"
+  settings (libraryDependencies ++= Seq(
+    Kafka.kafka              % Test,
+    `kafka-launcher`         % Test,
+    Slf4j.api                % Test,
+    Slf4j.`log4j-over-slf4j` % Test,
+    Logback.core             % Test,
+    Logback.classic          % Test,
+    scalatest                % Test
+  )))
+
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"

--- a/modules/play-json/src/main/scala/com/evolutiongaming/skafka/producer/JsonProducer.scala
+++ b/modules/play-json/src/main/scala/com/evolutiongaming/skafka/producer/JsonProducer.scala
@@ -14,15 +14,16 @@ trait JsonProducer[F[_]] {
 
 object JsonProducer {
 
-  def empty[F[_] : Applicative : FromTry]: JsonProducer[F] = apply(Producer.Send.empty[F])
+  def empty[F[_]: Applicative: FromTry]: JsonProducer[F] = apply(Producer.Send.empty[F])
 
-  implicit def jsValueToBytes[F[_] : FromTry]: ToBytes[F, JsValue] = {
-    (value: JsValue, _: Topic) => FromTry[F].apply {
+  implicit def jsValueToBytes[F[_]: FromTry]: ToBytes[F, JsValue] = { (value: JsValue, _: Topic) =>
+    FromTry[F].apply {
       Try(PlayJsonJsoniter.serialize(value)).orElse {
         Try(Json.toBytes(value))
       }
     }
   }
 
-  def apply[F[_] : FromTry](send: Producer.Send[F]): JsonProducer[F] = (record: ProducerRecord[String, JsValue]) => send(record)
+  def apply[F[_]: FromTry](send: Producer.Send[F]): JsonProducer[F] = (record: ProducerRecord[String, JsValue]) =>
+    send(record)
 }

--- a/modules/play-json/src/main/scala/com/evolutiongaming/skafka/producer/ToBytesFromWrites.scala
+++ b/modules/play-json/src/main/scala/com/evolutiongaming/skafka/producer/ToBytesFromWrites.scala
@@ -6,9 +6,10 @@ import play.api.libs.json.{JsValue, Writes}
 object ToBytesFromWrites {
 
   def apply[F[_], A](implicit writes: Writes[A], toBytes: ToBytes[F, JsValue]): ToBytes[F, A] = {
-    (value: A, topic: Topic) => {
-      val json = writes.writes(value)
-      toBytes(json, topic)
-    }
+    (value: A, topic: Topic) =>
+      {
+        val json = writes.writes(value)
+        toBytes(json, topic)
+      }
   }
 }

--- a/modules/play-json/src/test/scala/com/evolutiongaming/skafka/producer/JsonProducerSpec.scala
+++ b/modules/play-json/src/test/scala/com/evolutiongaming/skafka/producer/JsonProducerSpec.scala
@@ -11,25 +11,21 @@ class JsonProducerSpec extends AnyFunSuite with Matchers {
 
   test("apply") {
     val metadata = RecordMetadata(TopicPartition("topic", Partition.min))
-    var actual = Option.empty[(Option[Bytes], Option[Bytes])]
+    var actual   = Option.empty[(Option[Bytes], Option[Bytes])]
     type Id[A] = A
     val send = new Producer.Send[Id] {
-      def apply[K, V](
-        record: ProducerRecord[K, V])(implicit
-        toBytesK: ToBytes[Id, K],
-        toBytesV: ToBytes[Id, V]
-      ) = {
+      def apply[K, V](record: ProducerRecord[K, V])(implicit toBytesK: ToBytes[Id, K], toBytesV: ToBytes[Id, V]) = {
         val topic = record.topic
         val value = record.value.map(toBytesV(_, topic))
-        val key = record.key.map(toBytesK(_, topic))
+        val key   = record.key.map(toBytesK(_, topic))
         actual = Some((key, value))
         metadata
       }
     }
     val producer = JsonProducer(send)
 
-    val value = JsString("value")
-    val key = "key"
+    val value  = JsString("value")
+    val key    = "key"
     val record = ProducerRecord("topic", value, key)
     producer(record) shouldEqual metadata
     val (Some(keyBytes), valueBytes) = actual.get

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,26 +17,26 @@ object Dependencies {
 
   object Kafka {
     private val version = "2.5.0"
-    val kafka   = "org.apache.kafka" %% "kafka"         % version
-    val clients = "org.apache.kafka" %  "kafka-clients" % version
+    val kafka           = "org.apache.kafka" %% "kafka"         % version
+    val clients         = "org.apache.kafka"  % "kafka-clients" % version
   }
 
   object Logback {
     private val version = "1.2.3"
-    val core    = "ch.qos.logback" % "logback-core"    % version
-    val classic = "ch.qos.logback" % "logback-classic" % version
+    val core            = "ch.qos.logback" % "logback-core"    % version
+    val classic         = "ch.qos.logback" % "logback-classic" % version
   }
 
   object Slf4j {
-    private val version = "1.7.30"
+    private val version    = "1.7.30"
     val api                = "org.slf4j" % "slf4j-api"        % version
     val `log4j-over-slf4j` = "org.slf4j" % "log4j-over-slf4j" % version
   }
 
   object Cats {
     private val version = "2.3.0"
-    val core   = "org.typelevel" %% "cats-core"   % version
-    val effect = "org.typelevel" %% "cats-effect" % version
-    val laws   = "org.typelevel" %% "cats-laws"   % version
+    val core            = "org.typelevel" %% "cats-core"   % version
+    val effect          = "org.typelevel" %% "cats-effect" % version
+    val laws            = "org.typelevel" %% "cats-laws"   % version
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.27")

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/Converters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/Converters.scala
@@ -2,10 +2,10 @@ package com.evolutiongaming.skafka
 
 import java.lang.{Long => LongJ}
 import java.time.{Duration => DurationJ}
-import java.util.{Optional, Collection => CollectionJ, Map => MapJ, Set => SetJ, List => ListJ}
+import java.util.{Collection => CollectionJ, List => ListJ, Map => MapJ, Optional, Set => SetJ}
 
 import cats.Monad
-import cats.data.{NonEmptyList => Nel, NonEmptySet => Nes, NonEmptyMap => Nem}
+import cats.data.{NonEmptyList => Nel, NonEmptyMap => Nem, NonEmptySet => Nes}
 import cats.implicits._
 import com.evolutiongaming.catshelper.CatsHelper._
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, FromTry, MonadThrowable, ToTry}

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/TopicPartition.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/TopicPartition.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.skafka
 
-import cats.{Order, Show}
 import cats.implicits._
+import cats.{Order, Show}
 
 final case class TopicPartition(topic: Topic, partition: Partition) {
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
@@ -19,11 +19,11 @@ import com.evolutiongaming.skafka.consumer.ConsumerConverters._
 import com.evolutiongaming.smetrics.MeasureDuration
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.{
-  ConsumerRebalanceListener => ConsumerRebalanceListenerJ,
-  OffsetCommitCallback,
   Consumer => ConsumerJ,
+  ConsumerRebalanceListener => ConsumerRebalanceListenerJ,
   OffsetAndMetadata => OffsetAndMetadataJ,
-  OffsetAndTimestamp => OffsetAndTimestampJ
+  OffsetAndTimestamp => OffsetAndTimestampJ,
+  OffsetCommitCallback
 }
 import org.apache.kafka.common.{PartitionInfo => PartitionInfoJ, TopicPartition => TopicPartitionJ}
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerLogging.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerLogging.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.skafka.consumer
 import java.util.regex.Pattern
 
 import cats.Monad
-import cats.data.{NonEmptySet => Nes, NonEmptyMap => Nem}
+import cats.data.{NonEmptyMap => Nem, NonEmptySet => Nes}
 import cats.implicits._
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.skafka.{Offset, OffsetAndMetadata, Topic, TopicPartition}

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/CreateConsumerJ.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/CreateConsumerJ.scala
@@ -4,7 +4,7 @@ import cats.effect.Sync
 import com.evolutiongaming.catshelper.ToTry
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.FromBytes
-import org.apache.kafka.clients.consumer.{KafkaConsumer, Consumer => ConsumerJ}
+import org.apache.kafka.clients.consumer.{Consumer => ConsumerJ, KafkaConsumer}
 
 object CreateConsumerJ {
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceConsumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/RebalanceConsumer.scala
@@ -6,8 +6,8 @@ import java.util.{Map => MapJ}
 
 import cats.data.{NonEmptyMap => Nem, NonEmptySet => Nes}
 import com.evolutiongaming.skafka.Converters._
-import com.evolutiongaming.skafka.consumer.ConsumerConverters._
 import com.evolutiongaming.skafka._
+import com.evolutiongaming.skafka.consumer.ConsumerConverters._
 import org.apache.kafka.clients.consumer.{Consumer => ConsumerJ, OffsetAndMetadata => OffsetAndMetadataJ}
 import org.apache.kafka.common.{TopicPartition => TopicPartitionJ}
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -6,9 +6,9 @@ import cats.effect._
 import cats.effect.concurrent.Deferred
 import cats.implicits._
 import cats.{Applicative, Functor, MonadError, ~>}
-import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable}
 import com.evolutiongaming.catshelper.Blocking.implicits._
 import com.evolutiongaming.catshelper.CatsHelper._
+import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable}
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.producer.ProducerConverters._
 import com.evolutiongaming.smetrics.MeasureDuration
@@ -19,8 +19,8 @@ import org.apache.kafka.clients.producer.{
   RecordMetadata => RecordMetadataJ
 }
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, ExecutionException}
+import scala.jdk.CollectionConverters._
 
 /**
   * See [[org.apache.kafka.clients.producer.Producer]]

--- a/tests/src/test/scala/com/evolutiongaming/skafka/ProducerConsumerSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/skafka/ProducerConsumerSpec.scala
@@ -49,11 +49,12 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
       producer       <- producers
     } yield producer
 
-    val closeAll = producers.distinct.foldMapM { case (producer, release) =>
-      for {
-        _ <- producer.flush
-        _ <- release
-      } yield {}
+    val closeAll = producers.distinct.foldMapM {
+      case (producer, release) =>
+        for {
+          _ <- producer.flush
+          _ <- release
+        } yield {}
     }
 
     closeAll.unsafeRunTimed(timeout)
@@ -62,7 +63,6 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     super.afterAll()
   }
 
-
   val headers = List(Header(key = "key", value = "value".getBytes(UTF_8)))
 
   def consumerOf(
@@ -70,26 +70,29 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     listener: Option[RebalanceListener[IO]]
   ): Resource[IO, Consumer[IO, String, String]] = {
 
-    val config = ConsumerConfig.Default.copy(
-      groupId = Some(s"group-$topic"),
-      autoOffsetReset = AutoOffsetReset.Earliest,
-      autoCommit = false,
-      common = CommonConfig(clientId = Some(UUID.randomUUID().toString)))
+    val config = ConsumerConfig
+      .Default
+      .copy(
+        groupId         = Some(s"group-$topic"),
+        autoOffsetReset = AutoOffsetReset.Earliest,
+        autoCommit      = false,
+        common          = CommonConfig(clientId = Some(UUID.randomUUID().toString))
+      )
 
     for {
-      metrics    <- ConsumerMetrics.of(CollectorRegistry.empty[IO])
-      consumerOf  = ConsumerOf[IO](executor, metrics("clientId").some).mapK(FunctionK.id, FunctionK.id)
-      consumer   <- consumerOf[String, String](config)
-      _          <- consumer.subscribe(Nes.of(topic), listener).toResource
+      metrics   <- ConsumerMetrics.of(CollectorRegistry.empty[IO])
+      consumerOf = ConsumerOf[IO](executor, metrics("clientId").some).mapK(FunctionK.id, FunctionK.id)
+      consumer  <- consumerOf[String, String](config)
+      _         <- consumer.subscribe(Nes.of(topic), listener).toResource
     } yield consumer
   }
 
   def producerOf(acks: Acks): Resource[IO, Producer[IO]] = {
     val config = ProducerConfig.Default.copy(acks = acks)
     for {
-      metrics    <- ProducerMetrics.of(CollectorRegistry.empty[IO])
-      producerOf  = ProducerOf(executor, metrics("clientId").some).mapK(FunctionK.id, FunctionK.id)
-      producer   <- producerOf(config)
+      metrics   <- ProducerMetrics.of(CollectorRegistry.empty[IO])
+      producerOf = ProducerOf(executor, metrics("clientId").some).mapK(FunctionK.id, FunctionK.id)
+      producer  <- producerOf(config)
     } yield {
       producer.withLogging(Log.empty)
     }
@@ -113,7 +116,7 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
       assigned <- Deferred[IO, Unit]
       listener  = listenerOf(assigned = assigned)
       consumer  = consumerOf(topic, listener.some)
-      _        <- consumer.use { consumer =>
+      _ <- consumer.use { consumer =>
         val poll = consumer
           .poll(10.millis)
           .foreverM[Unit]
@@ -156,7 +159,7 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     // in `onPartitionsAssigned` - aggregate consumer.position responses in Set[Offset]
     // if the Set has only one element, then it works correctly
 
-    val topic = s"${instant.toEpochMilli}-rebalance-listener-correctness-position"
+    val topic                      = s"${instant.toEpochMilli}-rebalance-listener-correctness-position"
     val requiredNumberOfRebalances = 100
 
     def listenerOf(
@@ -173,7 +176,7 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
                 IO.delay(()) *>
                 IO.shift *>
                 IO.delay(())
-              ).lift
+            ).lift
             // with IO.shift attempts we make sure that
             // kafka java consumer.position method would be called from the same thread as consumer.poll
             // otherwise kafka java consumer throws
@@ -181,9 +184,9 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
             // which in result would terminate current flatMap chain
             // and fail the test as positions (Set[Offset]) would be empty
             position <- consumer.position(partitions.head)
-            _ <- positions.update(_.+(position)).lift
-            _ <- rebalanceCounter.update(_ + 1).lift
-            _ <- assigned.complete(()).lift
+            _        <- positions.update(_.+(position)).lift
+            _        <- rebalanceCounter.update(_ + 1).lift
+            _        <- assigned.complete(()).lift
           } yield ()
         }
 
@@ -194,13 +197,16 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     }
 
     val result = for {
-      testCompleted <- Deferred[IO, Unit]
-      positions <- Ref.of[IO, Set[Offset]](Set.empty)
+      testCompleted    <- Deferred[IO, Unit]
+      positions        <- Ref.of[IO, Set[Offset]](Set.empty)
       rebalanceCounter <- Ref.of[IO, Int](0)
       completeTestIfNeeded = for {
         rebalanceCounter <- rebalanceCounter.get
-        positions <- positions.get
-        completed <- if (rebalanceCounter >= requiredNumberOfRebalances || positions.size > 1) testCompleted.complete(()).handleError(_ => ()) else IO.unit
+        positions        <- positions.get
+        completed <-
+          if (rebalanceCounter >= requiredNumberOfRebalances || positions.size > 1)
+            testCompleted.complete(()).handleError(_ => ())
+          else IO.unit
       } yield completed
 
       consumer = consumerOf(topic, none)
@@ -215,12 +221,12 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
 
       testStep = Deferred[IO, Unit].flatMap { assigned =>
         val x = for {
-          _ <- Resource.release(completeTestIfNeeded)
+          _        <- Resource.release(completeTestIfNeeded)
           consumer <- consumer
-          listener = listenerOf(positions, rebalanceCounter, assigned)
-          _ <- consumer.subscribe(Nes.of(topic), listener).toResource
+          listener  = listenerOf(positions, rebalanceCounter, assigned)
+          _        <- consumer.subscribe(Nes.of(topic), listener).toResource
           poll = {
-              consumer.poll(10.millis).onError({ case e => IO.delay(println(s"${System.nanoTime()} poll failed $e")) })
+            consumer.poll(10.millis).onError({ case e => IO.delay(println(s"${System.nanoTime()} poll failed $e")) })
           }
           // without IO.cancelBoundary consumer.poll is called after consumer was closed
           // https://github.com/typelevel/cats-effect/issues/326#issuecomment-416925044
@@ -230,11 +236,20 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
       }
 
       _ <- Resource
-        .make(testStep.foreverM.start) {_.cancel}
+        .make(testStep.foreverM.start) { _.cancel }
         .use { _ =>
-          testCompleted.get.timeout(33.seconds)
-            .onError({ case _ => rebalanceCounter.get.map(c =>
-              println(s"rebalance listener correctness (position): onPartitionsAssigned $c out of $requiredNumberOfRebalances times"))
+          testCompleted
+            .get
+            .timeout(33.seconds)
+            .onError({
+              case _ =>
+                rebalanceCounter
+                  .get
+                  .map(c =>
+                    println(
+                      s"rebalance listener correctness (position): onPartitionsAssigned $c out of $requiredNumberOfRebalances times"
+                    )
+                  )
             })
         }
       positions <- positions.get
@@ -257,14 +272,14 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     // if the List == [0..N), then it works correctly,
     // as every commit was successfully executed
 
-    val topic = s"${instant.toEpochMilli}-rebalance-listener-correctness-commit"
+    val topic                      = s"${instant.toEpochMilli}-rebalance-listener-correctness-commit"
     val requiredNumberOfRebalances = 100
 
     def listenerOf(
-                    offsets: Ref[IO, List[Offset]],
-                    rebalanceCounter: Ref[IO, Int],
-                    assigned: Deferred[IO, Unit]
-                  ): RebalanceListener1[IO] = {
+      offsets: Ref[IO, List[Offset]],
+      rebalanceCounter: Ref[IO, Int],
+      assigned: Deferred[IO, Unit]
+    ): RebalanceListener1[IO] = {
       new RebalanceListener1WithConsumer[IO] {
 
         def onPartitionsAssigned(partitions: Nes[TopicPartition]) = {
@@ -277,9 +292,11 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
         def onPartitionsRevoked(partitions: Nes[TopicPartition]) =
           for {
             committed <- consumer.committed(partitions)
-            offset = committed.headOption.map(_._2.offset).getOrElse(Offset.min)
-            _ <- offsets.update(_ :+ offset).lift
-            a <- consumer.commit(partitions.map(_ -> OffsetAndMetadata(Offset.unsafe(offset.value + 1))).toNonEmptyList.toNem)
+            offset     = committed.headOption.map(_._2.offset).getOrElse(Offset.min)
+            _         <- offsets.update(_ :+ offset).lift
+            a <- consumer.commit(
+              partitions.map(_ -> OffsetAndMetadata(Offset.unsafe(offset.value + 1))).toNonEmptyList.toNem
+            )
           } yield a
 
         def onPartitionsLost(partitions: Nes[TopicPartition]) = RebalanceCallback.empty
@@ -287,12 +304,12 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     }
 
     val result = for {
-      testCompleted <- Deferred[IO, Unit]
-      offsets <- Ref.of[IO, List[Offset]](List.empty)
+      testCompleted    <- Deferred[IO, Unit]
+      offsets          <- Ref.of[IO, List[Offset]](List.empty)
       rebalanceCounter <- Ref.of[IO, Int](0)
       completeTestIfNeeded = for {
         rebalanceCounter <- rebalanceCounter.get
-        completed <- if (rebalanceCounter >= requiredNumberOfRebalances) testCompleted.complete(()) else IO.unit
+        completed        <- if (rebalanceCounter >= requiredNumberOfRebalances) testCompleted.complete(()) else IO.unit
       } yield completed
 
       consumer = consumerOf(topic, none)
@@ -305,8 +322,8 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
 
       testStep = Deferred[IO, Unit].flatMap { assigned =>
         consumer.use { consumer =>
-          val listener = listenerOf(offsets, rebalanceCounter, assigned)
-          val poll = consumer.poll(10.millis)
+          val listener  = listenerOf(offsets, rebalanceCounter, assigned)
+          val poll      = consumer.poll(10.millis)
           val subscribe = consumer.subscribe(Nes.of(topic), listener)
           subscribe *>
             Resource
@@ -321,9 +338,18 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
           _.cancel
         }
         .use { _ =>
-          testCompleted.get.timeout(33.seconds)
-            .onError({ case _ => rebalanceCounter.get.map(c =>
-              println(s"rebalance listener correctness (commit): onPartitionsAssigned $c out of $requiredNumberOfRebalances times"))
+          testCompleted
+            .get
+            .timeout(33.seconds)
+            .onError({
+              case _ =>
+                rebalanceCounter
+                  .get
+                  .map(c =>
+                    println(
+                      s"rebalance listener correctness (commit): onPartitionsAssigned $c out of $requiredNumberOfRebalances times"
+                    )
+                  )
             })
         }
       offsets <- offsets.get
@@ -359,17 +385,19 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
     val consumer = consumerOf(topic, none)
     val producer = producerOf(Acks.One)
 
-    producer.use { producer =>
-      for {
-        _ <- producer.send(ProducerRecord(topic, "value1", "key")).flatten
-        _ <- producer.send(ProducerRecord(topic, "value2", "key")).flatten
-      } yield ()
-    }.unsafeRunSync()
+    producer
+      .use { producer =>
+        for {
+          _ <- producer.send(ProducerRecord(topic, "value1", "key")).flatten
+          _ <- producer.send(ProducerRecord(topic, "value2", "key")).flatten
+        } yield ()
+      }
+      .unsafeRunSync()
 
     val consumeRecords: IO[List[(String, String)]] = consumer.use { consumer =>
       for {
-        _ <- consumer.subscribe(Nes.of(topic), listener)
-        poll = consumer.poll(10.millis)
+        _       <- consumer.subscribe(Nes.of(topic), listener)
+        poll     = consumer.poll(10.millis)
         records <- poll.iterateUntil(_.values.nonEmpty)
       } yield records.values.values.flatMap(_.toList.map(r => (r.key.get.value, r.value.get.value))).toList
     }
@@ -392,7 +420,7 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
   } yield {
 
     val topic = s"${instant.toEpochMilli}-$idx-$acks"
-    val name = s"[topic:$topic,acks:$acks]"
+    val name  = s"[topic:$topic,acks:$acks]"
 
     def produce(record: ProducerRecord[String, String]) = producer.send(record).flatten.unsafeRunSync()
 
@@ -402,50 +430,51 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
       .unsafeRunSync()
 
     test(s"$name produce and consume record") {
-      val key = "key1"
-      val value = "value1"
+      val key       = "key1"
+      val value     = "value1"
       val timestamp = instant
       val record = ProducerRecord(
-        topic = topic,
-        value = Some(value),
-        key = Some(key),
+        topic     = topic,
+        value     = Some(value),
+        key       = Some(key),
         timestamp = Some(timestamp),
-        headers = headers)
+        headers   = headers
+      )
       val metadata = produce(record)
-      val offset = if (acks == Acks.None) none[Offset] else Offset.min.some
+      val offset   = if (acks == Acks.None) none[Offset] else Offset.min.some
       metadata.offset shouldEqual offset
 
       val records = consumer.consume(timeout).map(Record(_))
 
       val expected = Record(
         record = ConsumerRecord(
-          topicPartition = metadata.topicPartition,
-          offset = Offset.min,
+          topicPartition   = metadata.topicPartition,
+          offset           = Offset.min,
           timestampAndType = Some(TimestampAndType(timestamp, TimestampType.Create)),
-          key = Some(WithSize(key, 4)),
-          value = Some(WithSize(value, 6)),
-          headers = Nil),
-        headers = List(Record.Header(key = "key", value = "value")))
+          key              = Some(WithSize(key, 4)),
+          value            = Some(WithSize(value, 6)),
+          headers          = Nil
+        ),
+        headers = List(Record.Header(key = "key", value = "value"))
+      )
 
       records shouldEqual List(expected)
     }
 
     test(s"$name produce and delete record") {
-      val key = "key2"
-      val record = ProducerRecord(topic, value = "value2", key = key)
+      val key      = "key2"
+      val record   = ProducerRecord(topic, value = "value2", key = key)
       val metadata = produce(record)
-      val offset = if (acks == Acks.None) none[Offset] else Offset.unsafe(1L).some
+      val offset   = if (acks == Acks.None) none[Offset] else Offset.unsafe(1L).some
       metadata.offset shouldEqual offset
 
-      val keyAndValues = consumer.consume(timeout).map { record => (record.key.map(_.value), record.value.map(_.value)) }
+      val keyAndValues =
+        consumer.consume(timeout).map { record => (record.key.map(_.value), record.value.map(_.value)) }
       keyAndValues shouldEqual List((Some(key), record.value))
 
       val timestamp = instant
-      val delete = ProducerRecord[String, String](
-        topic = topic,
-        key = Some(key),
-        timestamp = Some(timestamp),
-        headers = headers)
+      val delete =
+        ProducerRecord[String, String](topic = topic, key = Some(key), timestamp = Some(timestamp), headers = headers)
 
       val deleteMetadata = produce(delete)
 
@@ -453,22 +482,21 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
 
       val expected = Record(
         record = ConsumerRecord[String, String](
-          topicPartition = deleteMetadata.topicPartition,
-          offset = Offset.unsafe(2),
+          topicPartition   = deleteMetadata.topicPartition,
+          offset           = Offset.unsafe(2),
           timestampAndType = Some(TimestampAndType(timestamp, TimestampType.Create)),
-          key = Some(WithSize(key, 4)),
-          headers = Nil),
-        headers = List(Record.Header(key = "key", value = "value")))
+          key              = Some(WithSize(key, 4)),
+          headers          = Nil
+        ),
+        headers = List(Record.Header(key = "key", value = "value"))
+      )
 
       records shouldEqual List(expected)
     }
 
     test(s"$name produce and consume empty record") {
       val timestamp = instant
-      val empty = ProducerRecord[String, String](
-        topic = topic,
-        timestamp = Some(timestamp),
-        headers = headers)
+      val empty     = ProducerRecord[String, String](topic = topic, timestamp = Some(timestamp), headers = headers)
 
       val metadata = produce(empty)
 
@@ -476,29 +504,32 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
 
       val expected = Record(
         record = ConsumerRecord[String, String](
-          topicPartition = metadata.topicPartition,
-          offset = Offset.unsafe(3),
+          topicPartition   = metadata.topicPartition,
+          offset           = Offset.unsafe(3),
           timestampAndType = Some(TimestampAndType(timestamp, TimestampType.Create)),
-          headers = Nil),
-        headers = List(Record.Header(key = "key", value = "value")))
+          headers          = Nil
+        ),
+        headers = List(Record.Header(key = "key", value = "value"))
+      )
 
       records shouldEqual List(expected)
     }
 
     test(s"$name commit and subscribe from last committed position") {
-      val key = "key3"
-      val value = "value3"
+      val key       = "key3"
+      val value     = "value3"
       val timestamp = instant
 
       Await.result(consumer.commit(), timeout)
       consumerRelease.unsafeRunSync()
 
       val record = ProducerRecord(
-        topic = topic,
-        value = Some(value),
-        key = Some(key),
+        topic     = topic,
+        value     = Some(value),
+        key       = Some(key),
         timestamp = Some(timestamp),
-        headers = headers)
+        headers   = headers
+      )
 
       val metadata = produce(record)
 
@@ -508,13 +539,15 @@ class ProducerConsumerSpec extends AnyFunSuite with BeforeAndAfterAll with Match
 
       val expected = Record(
         record = ConsumerRecord(
-          topicPartition = metadata.topicPartition,
-          offset = Offset.unsafe(4L),
+          topicPartition   = metadata.topicPartition,
+          offset           = Offset.unsafe(4L),
           timestampAndType = Some(TimestampAndType(timestamp, TimestampType.Create)),
-          key = WithSize(key, 4).some,
-          value = WithSize(value, 6).some,
-          headers = Nil),
-        headers = List(Record.Header(key = "key", value = "value")))
+          key              = WithSize(key, 4).some,
+          value            = WithSize(value, 6).some,
+          headers          = Nil
+        ),
+        headers = List(Record.Header(key = "key", value = "value"))
+      )
 
       records shouldEqual List(expected)
 
@@ -534,9 +567,7 @@ object ProducerConsumerSpec {
       val headers = record.headers.map { header =>
         Header(key = header.key, value = new String(header.value, UTF_8))
       }
-      Record(
-        record = record.copy(headers = Nil),
-        headers = headers)
+      Record(record = record.copy(headers = Nil), headers = headers)
     }
 
     final case class Header(key: String, value: String)
@@ -549,7 +580,7 @@ object ProducerConsumerSpec {
       def consume(attempts: Int): List[ConsumerRecord[String, String]] = {
         if (attempts <= 0) Nil
         else {
-          val future = self.poll(100.millis).unsafeToFuture()
+          val future  = self.poll(100.millis).unsafeToFuture()
           val records = Await.result(future, timeout).values.values.flatMap(_.toList)
           if (records.isEmpty) consume(attempts - 1)
           else records.toList


### PR DESCRIPTION
This introduces scalafix with [OrganizeImports](https://github.com/liancheng/scalafix-organize-imports).
The configuration is trying to mimic IntelliJ IDEA optimizing, so it should (in theory) produce the same results.
Should mention that scalafix is not responsible for formatting imports according to scalafmt config (as described by the author [here](https://github.com/liancheng/scalafix-organize-imports/issues/173)), thus one should first run scalafix (which organizes imports and optimizes them) and then run scalafmt (which pretty-prints imports according to its config).
If using from Metals, it's enough to run metals action `Organize imports` (either from command palette or by keyboard shortcut) and then format the file.
If using from console (or CI/CD), first `sbt "scalafix OrganizeImports"` and then `./scalafmt`.

In this PR you can see the result of applying these commands to the project. I forgot to run `scalafmt` in the root of the project in the previous PR, so `play-json` and SBT files are also "formatted" according to scalafmt config now.
Other than that it seems like organizing imports didn't have much of the effect on the codebase - some small import juggling here and there.  
This is a draft so please feel free to make comments, probably we don't even need this - I'm OK with that too.