### PR TITLE
Don't unsafely run effect from Producer's send callback

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -2,8 +2,8 @@ package com.evolutiongaming.skafka
 package producer
 
 import cats.data.{NonEmptyMap => Nem}
-import cats.effect.{Async, Resource, Sync}
 import cats.effect.implicits._
+import cats.effect.{Async, Resource, Sync}
 import cats.implicits._
 import cats.{Applicative, Functor, MonadError, ~>}
 import com.evolutiongaming.catshelper.CatsHelper._
@@ -11,12 +11,7 @@ import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable, ToTry}
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.producer.ProducerConverters._
 import com.evolutiongaming.smetrics.MeasureDuration
-import org.apache.kafka.clients.producer.{
-  Callback,
-  Producer => ProducerJ,
-  ProducerRecord => ProducerRecordJ,
-  RecordMetadata => RecordMetadataJ
-}
+import org.apache.kafka.clients.producer.{Callback, Producer => ProducerJ, ProducerRecord => ProducerRecordJ, RecordMetadata => RecordMetadataJ}
 
 import scala.concurrent.{ExecutionContext, ExecutionException, Promise}
 import scala.jdk.CollectionConverters._

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -7,7 +7,7 @@ import cats.effect.{Async, Resource, Sync}
 import cats.implicits._
 import cats.{Applicative, Functor, MonadError, ~>}
 import com.evolutiongaming.catshelper.CatsHelper._
-import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable, ToTry}
+import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable}
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.producer.ProducerConverters._
 import com.evolutiongaming.smetrics.MeasureDuration
@@ -86,14 +86,14 @@ object Producer {
   }
 
   @deprecated("Use of(ProducerConfig)", since = "12.0.1")
-  def of[F[_]: ToTry: Async](
+  def of[F[_]: Async](
     config: ProducerConfig,
     executorBlocking: ExecutionContext
   ): Resource[F, Producer[F]] = {
     of(config)
   }
 
-  def of[F[_]: ToTry: Async](
+  def of[F[_]: Async](
     config: ProducerConfig
   ): Resource[F, Producer[F]] = {
     val producer = CreateProducerJ(config)
@@ -103,11 +103,11 @@ object Producer {
   private sealed abstract class Main
 
   @deprecated("Use fromProducerJ2", since = "12.0.1")
-  def fromProducerJ1[F[_]: Blocking: ToTry: Async](producer: F[ProducerJ[Bytes, Bytes]]): Resource[F, Producer[F]] = {
+  def fromProducerJ1[F[_]: Blocking: Async](producer: F[ProducerJ[Bytes, Bytes]]): Resource[F, Producer[F]] = {
     fromProducerJ2(producer)
   }
 
-  def fromProducerJ2[F[_]: ToTry: Async](producer: F[ProducerJ[Bytes, Bytes]]): Resource[F, Producer[F]] = {
+  def fromProducerJ2[F[_]: Async](producer: F[ProducerJ[Bytes, Bytes]]): Resource[F, Producer[F]] = {
 
     def blocking[A](f: => A) = Sync[F].blocking(f)
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerOf.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerOf.scala
@@ -2,7 +2,6 @@ package com.evolutiongaming.skafka.producer
 
 import cats.effect.{Async, MonadCancel, Resource}
 import cats.~>
-import com.evolutiongaming.catshelper.ToTry
 import com.evolutiongaming.smetrics.MeasureDuration
 
 import scala.concurrent.ExecutionContext
@@ -15,12 +14,12 @@ trait ProducerOf[F[_]] {
 object ProducerOf {
 
   @deprecated("Use apply1", since = "12.0.1")
-  def apply[F[_]: MeasureDuration: ToTry: Async](
+  def apply[F[_]: MeasureDuration: Async](
     executorBlocking: ExecutionContext,
     metrics: Option[ProducerMetrics[F]] = None
   ): ProducerOf[F] = apply1(metrics = metrics)
 
-  def apply1[F[_]: MeasureDuration: ToTry: Async](
+  def apply1[F[_]: MeasureDuration: Async](
     metrics: Option[ProducerMetrics[F]] = None
   ): ProducerOf[F] = new ProducerOf[F] {
 


### PR DESCRIPTION
Even though semantically the behaviour is the same, I think it is a bit cleaner when we don't "unsafely" run the effect (completing `Deferred`) via `ToTry` in `Producer#send` callback.

Also as the docs state the `Callback` is generally executed in the I/O thread of the producer, so it should be as fast as possible. To me it seems that completing a `Promise` is more lightweight than executing an effect of completing `Deferred`.
