### PR TITLE
Trim too large records on producer failures

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -5,9 +5,9 @@ import cats.data.{NonEmptyMap => Nem}
 import cats.effect.{Resource, Sync, Async, Deferred}
 import cats.effect.implicits._
 import cats.implicits._
-import cats.{Applicative, Functor, MonadError, ~>}
+import cats.{Applicative, Functor, MonadError, MonadThrow, ~>}
 import com.evolutiongaming.catshelper.CatsHelper._
-import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable, ToTry}
+import com.evolutiongaming.catshelper.{Blocking, Log, ToTry}
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.producer.ProducerConverters._
 import com.evolutiongaming.smetrics.MeasureDuration
@@ -320,8 +320,15 @@ object Producer {
 
   implicit class ProducerOps[F[_]](val self: Producer[F]) extends AnyVal {
 
-    def withLogging(log: Log[F])(implicit F: MonadThrowable[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+    def withLogging(log: Log[F])(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
       ProducerLogging(self, log)
+    }
+
+    /**
+      * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
+      */
+    def withLogging(log: Log[F], charsToTrim: Int)(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+      ProducerLogging(self, log, charsToTrim)
     }
 
     def withMetrics[E](

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
@@ -12,10 +12,13 @@ object ProducerLogging {
 
   private sealed abstract class WithLogging
 
+  def apply[F[_]: MonadThrow: MeasureDuration](producer: Producer[F], log: Log[F]): Producer[F] =
+    apply(producer, log, charsToTrim = 1024)
+
   /**
     * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
     */
-  def apply[F[_]: MonadThrow: MeasureDuration](producer: Producer[F], log: Log[F], charsToTrim: Int = 1024): Producer[F] = {
+  def apply[F[_]: MonadThrow: MeasureDuration](producer: Producer[F], log: Log[F], charsToTrim: Int): Producer[F] = {
 
     new WithLogging with Producer[F] {
       def initTransactions = producer.initTransactions


### PR DESCRIPTION
Currently, records that are too large to produce are simply printed as-is which leads to humongous log messages of 1 and more megabytes in size.  
This PR improves logging in case `RecordTooLargeException` occurs, taking only the first 256 chars to get a brief idea what was in the record. 