### PR TITLE
Trim too large records on producer failures

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -7,7 +7,7 @@ import cats.effect.syntax.all._
 import cats.effect.concurrent.Deferred
 import cats.syntax.all._
 import cats.{Applicative, Functor, MonadError, ~>}
-import com.evolutiongaming.catshelper.{Blocking, Log, MonadThrowable, ToTry}
+import com.evolutiongaming.catshelper.{Blocking, Log, ToTry}
 import com.evolutiongaming.catshelper.Blocking.implicits._
 import com.evolutiongaming.catshelper.CatsHelper._
 import com.evolutiongaming.skafka.Converters._
@@ -430,8 +430,15 @@ object Producer {
 
   implicit class ProducerOps[F[_]](val self: Producer[F]) extends AnyVal {
 
-    def withLogging(log: Log[F])(implicit F: MonadThrowable[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+    def withLogging(log: Log[F])(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
       ProducerLogging(self, log)
+    }
+
+    /**
+      * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
+      */
+    def withLogging(log: Log[F], charsToTrim: Int)(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+      ProducerLogging(self, log, charsToTrim)
     }
 
     def withMetrics[E](

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
@@ -12,6 +12,9 @@ object ProducerLogging {
 
   private sealed abstract class WithLogging
 
+  def apply[F[_]: MonadThrow: MeasureDuration](producer: Producer[F], log: Log[F]): Producer[F] =
+    apply(producer, log, charsToTrim = 1024)
+
   /**
     * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
     */


### PR DESCRIPTION
Currently, records that are too large to produce are simply printed as-is which leads to humongous log messages of 1 and more megabytes in size.
This PR improves logging in case RecordTooLargeException occurs, taking only the first 256 chars to get a brief idea what was in the record.

This is a duplicate of https://github.com/evolution-gaming/skafka/pull/255 but for CE2-compatible branch.