### PR TITLE
Use testcontainers-kafka for integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,7 @@ lazy val tests = (project in file("tests")
   settings Seq(publish / skip := true, Test / fork := true, Test / parallelExecution := false)
   dependsOn skafka % "compile->compile;test->test"
   settings (libraryDependencies ++= Seq(
-    Kafka.kafka              % Test,
-    `kafka-launcher`         % Test,
+    `testcontainers-kafka`   % Test,
     Slf4j.api                % Test,
     Slf4j.`log4j-over-slf4j` % Test,
     Logback.core             % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,21 +2,20 @@ import sbt._
 
 object Dependencies {
 
-  val `executor-tools`     = "com.evolutiongaming"    %% "executor-tools"          % "1.0.2"
-  val `config-tools`       = "com.evolutiongaming"    %% "config-tools"            % "1.0.4"
-  val `future-helper`      = "com.evolutiongaming"    %% "future-helper"           % "1.0.6"
-  val `cats-helper`        = "com.evolutiongaming"    %% "cats-helper"             % "3.5.0"
-  val `kafka-launcher`     = "com.evolutiongaming"    %% "kafka-launcher"          % "0.1.0"
-  val `play-json-jsoniter` = "com.evolutiongaming"    %% "play-json-jsoniter"      % "0.10.0"
-  val `scala-java8-compat` = "org.scala-lang.modules" %% "scala-java8-compat"      % "1.0.2"
-  val `collection-compat`  = "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
-  val scalatest            = "org.scalatest"          %% "scalatest"               % "3.2.13"
-  val `kind-projector`     = "org.typelevel"           % "kind-projector"          % "0.13.2"
-  val discipline           = "org.typelevel"          %% "discipline-scalatest"    % "2.2.0"
+  val `executor-tools`        = "com.evolutiongaming"    %% "executor-tools"              % "1.0.2"
+  val `config-tools`          = "com.evolutiongaming"    %% "config-tools"                % "1.0.4"
+  val `future-helper`         = "com.evolutiongaming"    %% "future-helper"               % "1.0.6"
+  val `cats-helper`           = "com.evolutiongaming"    %% "cats-helper"                 % "3.5.0"
+  val `testcontainers-kafka`  = "com.dimafeng"           %% "testcontainers-scala-kafka"  % "0.40.17"
+  val `play-json-jsoniter`    = "com.evolutiongaming"    %% "play-json-jsoniter"          % "0.10.0"
+  val `scala-java8-compat`    = "org.scala-lang.modules" %% "scala-java8-compat"          % "1.0.2"
+  val `collection-compat`     = "org.scala-lang.modules" %% "scala-collection-compat"     % "2.8.1"
+  val scalatest               = "org.scalatest"          %% "scalatest"                   % "3.2.13"
+  val `kind-projector`        = "org.typelevel"           % "kind-projector"              % "0.13.2"
+  val discipline              = "org.typelevel"          %% "discipline-scalatest"        % "2.2.0"
 
   object Kafka {
     private val version = "3.4.0"
-    val kafka           = "org.apache.kafka" %% "kafka"         % version
     val clients         = "org.apache.kafka"  % "kafka-clients" % version
   }
 


### PR DESCRIPTION
Motivation: we avoid pulling Kafka broker code into our test scope. This has a few benefits:
- Kafka broker is independent of the Java version used. It's not an issue as far as I currently know, but it might be in the same spirit it was for Cassandra which required additional settings to be run with Java 11+
- we can safely update our dependencies without possibly affecting Kafka broker (as they are in the same classpath currently)
- it models a test case that's closer to a live usage - a separate broker, running in a separate container, rather than in the same JVM
- it opens up a possible path of cross-compiling this library to Scala 3 since Kafka broker code is compiled against a specific Scala version
- we bring fewer dependencies to the test scope, using only those we bring in with `kafka-clients` library
- there won't be a mismatch between the used `kafka-clients` and Kafka broker versions. Using a different version is a matter of updating `testcontainers-scala-kafka` dependency or specifying a different image version manually