### PR TITLE
Add withMetrics1 method for partial binary compatibility

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
@@ -1330,6 +1330,17 @@ object Consumer {
       }
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+      * version (namely, 15.2.0) which had `withMetrics1` method using `MeasureDuration` from `smetrics`
+      * and `withMetrics2` using `MeasureDuration` from `cats-helper`.
+      * This should not be used and should be removed in a reasonable amount of time.
+      */
+    @deprecated("Use `withMetrics1`", since = "16.0.2")
+    def withMetrics2[E](
+      metrics: ConsumerMetrics[F]
+    )(implicit F: MonadError[F, E], measureDuration: MeasureDuration[F], clock: Clock[F]): Consumer[F, K, V] =
+      withMetrics1(metrics)
+
     def withLogging(log: Log[F])(implicit F: Monad[F], measureDuration: MeasureDuration[F]): Consumer[F, K, V] = {
       ConsumerLogging(log, self)
     }

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -355,6 +355,7 @@ object Producer {
       * and `withMetrics1` using `MeasureDuration` from `cats-helper`.
       * This should not be used and should be removed in a reasonable amount of time.
       */
+    @deprecated("Use `withMetrics`", since = "16.0.2")
     def withMetrics1[E](
       metrics: ProducerMetrics[F]
     )(implicit F: MonadError[F, E], measureDuration: MeasureDuration[F]): Producer[F] = {

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -350,6 +350,17 @@ object Producer {
       Producer(self, metrics)
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+      * version (namely, 15.2.0) which had `withMetrics` method using `MeasureDuration` from `smetrics`
+      * and `withMetrics1` using `MeasureDuration` from `cats-helper`.
+      * This should not be used and should be removed in a reasonable amount of time.
+      */
+    def withMetrics1[E](
+      metrics: ProducerMetrics[F]
+    )(implicit F: MonadError[F, E], measureDuration: MeasureDuration[F]): Producer[F] = {
+      withMetrics(metrics)
+    }
+
     def mapK[G[_]: Functor](fg: F ~> G, gf: G ~> F)(implicit F: Monad[F]): Producer[G] = new MapK with Producer[G] {
 
       def initTransactions = fg(self.initTransactions)


### PR DESCRIPTION
Motivation:
In an intermediate version 15.2.0 there were [two methods](https://github.com/evolution-gaming/skafka/blob/v15.2.0/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala#L376-L388
) for creating a metered producer:
- a deprecated `withMetrics` using `MeasureDuration` from `smetrics`
- `withMetrics1` using `MeasureDuration` from `cats-helper`

There's only one `withMetrics` method now, using `MeasureDuration` from cats-helper.

The same goes for consumer: https://github.com/evolution-gaming/skafka/blob/v15.2.0/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala#L955-L969

If library `A` depends on `v15.2.0` and calls `withMetrics1`, and library `B` depends on `A` but evicts `skafka` to `16.0.0`, then `B` calls `A`, `A` calls `withMetrics1`, but there's no such method in `skafka` `v16.0.0`, so it fails with a runtime error.

This PR tries to fix that, at least partially.