### PR TITLE
Add Producer.withMetrics1/Consumer.withMetrics2 methods for partial binary compatibility [CE2]

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
@@ -1320,6 +1320,17 @@ object Consumer {
       }
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+      * version (namely, 11.15.1) which had `withMetrics1` method using `MeasureDuration` from `smetrics`
+      * and `withMetrics2` using `MeasureDuration` from `cats-helper`.
+      * This should not be used and should be removed in a reasonable amount of time.
+      */
+    @deprecated("Use `withMetrics1`", since = "11.16.2")
+    def withMetrics2[E](
+      metrics: ConsumerMetrics[F]
+    )(implicit F: MonadError[F, E], measureDuration: MeasureDuration[F], clock: Clock[F]): Consumer[F, K, V] =
+      withMetrics1(metrics)
+
     def withLogging(log: Log[F])(implicit F: Monad[F], measureDuration: MeasureDuration[F]): Consumer[F, K, V] = {
       ConsumerLogging(log, self)
     }

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -456,6 +456,18 @@ object Producer {
       Producer(self, metrics)
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+     * version (namely, 11.15.1) which had `withMetrics` method using `MeasureDuration` from `smetrics`
+     * and `withMetrics1` using `MeasureDuration` from `cats-helper`.
+     * This should not be used and should be removed in a reasonable amount of time.
+     */
+    @deprecated("Use `withMetrics`", since = "11.16.2")
+    def withMetrics1[E](
+      metrics: ProducerMetrics[F]
+    )(implicit F: MonadError[F, E], measureDuration: MeasureDuration[F]): Producer[F] = {
+      withMetrics(metrics)
+    }
+
     def mapK[G[_]: Functor](fg: F ~> G, gf: G ~> F)(implicit F: Monad[F]): Producer[G] = new MapK with Producer[G] {
 
       def initTransactions = fg(self.initTransactions)


### PR DESCRIPTION
This is a backport of https://github.com/evolution-gaming/skafka/pull/372