### PR TITLE
Add Producer.withLogging1/Consumer.withLogging1 for binary compatibility [CE2]

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
@@ -1335,6 +1335,16 @@ object Consumer {
       ConsumerLogging(log, self)
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+     * version (namely, 11.15.1) which had `withLogging` method using `MeasureDuration` from `smetrics`
+     * and `withLogging1` using `MeasureDuration` from `cats-helper`.
+     * This should not be used and should be removed in a reasonable amount of time.
+     */
+    @deprecated("Use `withLogging`", since = "11.16.2")
+    def withLogging1(log: Log[F])(implicit F: Monad[F], measureDuration: MeasureDuration[F]): Consumer[F, K, V] = {
+      withLogging(log)
+    }
+
     def mapK[G[_]](fg: F ~> G, gf: G ~> F)(implicit F: Monad[F]): Consumer[G, K, V] = new MapK with Consumer[G, K, V] {
 
       def assign(partitions: Nes[TopicPartition]) = fg(self.assign(partitions))

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -443,11 +443,33 @@ object Producer {
       ProducerLogging(self, log)
     }
 
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+     *  version (namely, 11.15.1) which had `withLogging` method using `MeasureDuration` from `smetrics`
+     *  and `withLogging1` using `MeasureDuration` from `cats-helper`.
+     *  This should not be used and should be removed in a reasonable amount of time.
+     */
+    @deprecated("Use `withLogging`", since = "11.16.2")
+    def withLogging1(log: Log[F])(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+      withLogging(log)
+    }
+
     /**
       * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
       */
     def withLogging(log: Log[F], charsToTrim: Int)(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
       ProducerLogging(self, log, charsToTrim)
+    }
+
+    /** The sole purpose of this method is to support binary compatibility with an intermediate
+     *  version (namely, 11.15.1) which had `withLogging` method using `MeasureDuration` from `smetrics`
+     *  and `withLogging1` using `MeasureDuration` from `cats-helper`.
+     *  This should not be used and should be removed in a reasonable amount of time.
+     *
+     * @param charsToTrim a number of chars from record's value to log when producing fails because of a too large record
+     */
+    @deprecated("Use `withLogging`", since = "11.16.2")
+    def withLogging1(log: Log[F], charsToTrim: Int)(implicit F: MonadThrow[F], measureDuration: MeasureDuration[F]): Producer[F] = {
+      withLogging(log, charsToTrim)
     }
 
     def withMetrics[E](


### PR DESCRIPTION
This is a continuation of https://github.com/evolution-gaming/skafka/pull/373 and a back-port of https://github.com/evolution-gaming/skafka/pull/374