### PR TITLE
Add ProducerOf.apply2/ConsumerOf.apply2 for binary compatibility

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerOf.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerOf.scala
@@ -38,6 +38,16 @@ object ConsumerOf {
     }
   }
 
+  /** The sole purpose of this method is to support binary compatibility with an intermediate
+   *  version (namely, 15.2.0) which had `apply1` method using `MeasureDuration` from `smetrics`
+   *  and `apply2` using `MeasureDuration` from `cats-helper`.
+   *  This should not be used and should be removed in a reasonable amount of time.
+   */
+  @deprecated("Use `apply1`", since = "16.0.3")
+  def apply2[F[_] : Async : ToTry : ToFuture : MeasureDuration](
+    metrics: Option[ConsumerMetrics[F]] = None
+  ): ConsumerOf[F] = apply1(metrics)
+
   implicit class ConsumerOfOps[F[_]](val self: ConsumerOf[F]) extends AnyVal {
 
     def mapK[G[_]](

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerOf.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerOf.scala
@@ -32,6 +32,16 @@ object ProducerOf {
     }
   }
 
+  /** The sole purpose of this method is to support binary compatibility with an intermediate
+   *  version (namely, 15.2.0) which had `apply1` method using `MeasureDuration` from `smetrics`
+   *  and `apply2` using `MeasureDuration` from `cats-helper`.
+   *  This should not be used and should be removed in a reasonable amount of time.
+   */
+  @deprecated("Use `apply1`", since = "16.0.3")
+  def apply2[F[_] : MeasureDuration : ToTry : Async](
+    metrics: Option[ProducerMetrics[F]] = None
+  ): ProducerOf[F] = apply1(metrics)
+
   implicit class ProducerOfOps[F[_]](val self: ProducerOf[F]) extends AnyVal {
 
     def mapK[G[_]](


### PR DESCRIPTION
This is continuation of https://github.com/evolution-gaming/skafka/pull/372 for `ConsumerOf`/`ProducerOf` factory methods