### PR TITLE
Update a default partition.assignment.strategy to match Kafka 3.x.x

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConfig.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConfig.scala
@@ -20,7 +20,7 @@ final case class ConsumerConfig(
   heartbeatInterval: FiniteDuration          = 3.seconds,
   autoCommit: Boolean                        = true,
   autoCommitInterval: Option[FiniteDuration] = None,
-  partitionAssignmentStrategy: String        = "org.apache.kafka.clients.consumer.RangeAssignor",
+  partitionAssignmentStrategy: String        = "org.apache.kafka.clients.consumer.RangeAssignor,org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
   autoOffsetReset: AutoOffsetReset           = AutoOffsetReset.Latest,
   defaultApiTimeout: FiniteDuration          = 1.minute,
   fetchMinBytes: Int                         = 1,

--- a/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/ConsumerConfigSpec.scala
+++ b/skafka/src/test/scala/com/evolutiongaming/skafka/consumer/ConsumerConfigSpec.scala
@@ -104,7 +104,7 @@ class ConsumerConfigSpec extends AnyFunSuite with Matchers {
       "exclude.internal.topics"                  -> "true",
       "reconnect.backoff.max.ms"                 -> "1000",
       "auto.offset.reset"                        -> "latest",
-      "partition.assignment.strategy"            -> "org.apache.kafka.clients.consumer.RangeAssignor",
+      "partition.assignment.strategy"            -> "org.apache.kafka.clients.consumer.RangeAssignor,org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
       "heartbeat.interval.ms"                    -> "3000",
       "check.crcs"                               -> "true",
       "auto.commit.interval.ms"                  -> "5000",


### PR DESCRIPTION
3.x.x [documentation](https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy) states:
> ```The default assignor is [RangeAssignor, CooperativeStickyAssignor], which will use the RangeAssignor by default, but allows upgrading to the CooperativeStickyAssignor with just a single rolling bounce that removes the RangeAssignor from the list.```

This was [introduced](https://kafka.apache.org/documentation/#upgrade_300_notable) in 3.0.0:
> ```The default partition.assignment.strategy is changed to "[RangeAssignor, CooperativeStickyAssignor]", which will use the RangeAssignor by default, but allows upgrading to the CooperativeStickyAssignor with just a single rolling bounce that removes the RangeAssignor from the list. Please check the client upgrade path guide [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429:+Kafka+Consumer+Incremental+Rebalance+Protocol#KIP429:KafkaConsumerIncrementalRebalanceProtocol-Consumer) for more detail.```