### PR TITLE
fix compatibility with kafka-clients 3.7.0, by using local version of NoOpConsumerRebalanceListener

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/Consumer.scala
@@ -11,7 +11,6 @@ import com.evolutiongaming.catshelper.CatsHelper._
 import com.evolutiongaming.catshelper._
 import com.evolutiongaming.skafka.Converters._
 import com.evolutiongaming.skafka.consumer.ConsumerConverters._
-import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.{
   OffsetCommitCallback,
   Consumer => ConsumerJ,

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/NoOpConsumerRebalanceListener.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/NoOpConsumerRebalanceListener.scala
@@ -1,0 +1,15 @@
+package com.evolutiongaming.skafka.consumer
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.common.TopicPartition
+
+import java.util
+
+/** Local version of NoOpConsumerRebalanceListener, because it was removed in kafka-clients 3.7.0
+  */
+private[skafka] final class NoOpConsumerRebalanceListener extends ConsumerRebalanceListener {
+
+  override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = ()
+
+  override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = ()
+}


### PR DESCRIPTION
Fixes #415 