### PR TITLE
Expose Java client metrics via factory from ClientId

### DIFF
--- a/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
+++ b/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
@@ -28,26 +28,7 @@ object ConsumerMetricsOf {
       registry <- KafkaMetricsRegistry.of(prometheus, prefix)
     } yield { (clientId: ClientId) =>
       val source = sourceOf(clientId)
-
-      new ConsumerMetrics[F] {
-        override def call(name: String, topic: Topic, latency: FiniteDuration, success: Boolean): F[Unit] =
-          source.call(name, topic, latency, success)
-
-        override def poll(topic: Topic, bytes: Int, records: Int, age: Option[FiniteDuration]): F[Unit] =
-          source.poll(topic, bytes, records, age)
-
-        override def count(name: String, topic: Topic): F[Unit] =
-          source.count(name, topic)
-
-        override def rebalance(name: String, topicPartition: TopicPartition): F[Unit] =
-          source.rebalance(name, topicPartition)
-
-        override def topics(latency: FiniteDuration): F[Unit] =
-          source.topics(latency)
-
-        override def exposeJavaMetrics[K, V](consumer: Consumer[F, K, V]): Resource[F, Unit] =
-          registry.register(consumer.clientMetrics)
-      }
+      consumerMetricsOf(source, registry)
     }
 
   /**
@@ -65,7 +46,13 @@ object ConsumerMetricsOf {
   ): Resource[F, ConsumerMetrics[F]] =
     for {
       registry <- KafkaMetricsRegistry.of(prometheus, prefix)
-    } yield new ConsumerMetrics[F] {
+    } yield consumerMetricsOf(source, registry)
+
+  private def consumerMetricsOf[F[_]](
+    source: ConsumerMetrics[F],
+    registry: KafkaMetricsRegistry[F],
+  ): ConsumerMetrics[F] =
+    new ConsumerMetrics[F] {
       override def call(name: String, topic: Topic, latency: FiniteDuration, success: Boolean): F[Unit] =
         source.call(name, topic, latency, success)
 

--- a/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
+++ b/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
@@ -8,8 +8,48 @@ import com.evolutiongaming.skafka.metrics.KafkaMetricsRegistry
 import io.prometheus.client.CollectorRegistry
 
 import scala.concurrent.duration.FiniteDuration
+import com.evolutiongaming.skafka.ClientId
 
 object ConsumerMetricsOf {
+
+  /**
+    * Construct [[ConsumerMetrics]] that will expose Java Kafka client metrics.
+    *
+    * @param sourceOf original [[ConsumerMetrics]] factory
+    * @param prometheus instance of Prometheus registry
+    * @param prefix metric name prefix
+    * @return [[ConsumerMetrics]] that exposes Java Kafka client metrics
+    */
+  def withJavaClientMetrics[F[_]: Sync: ToTry: UUIDGen](
+    sourceOf: ClientId => ConsumerMetrics[F],
+    prometheus: CollectorRegistry,
+    prefix: Option[String],
+  ): Resource[F, ClientId => ConsumerMetrics[F]] =
+    for {
+      registry <- KafkaMetricsRegistry.of(prometheus, prefix)
+    } yield { (clientId: ClientId) =>
+      val source = sourceOf(clientId)
+
+      new ConsumerMetrics[F] {
+        override def call(name: String, topic: Topic, latency: FiniteDuration, success: Boolean): F[Unit] =
+          source.call(name, topic, latency, success)
+
+        override def poll(topic: Topic, bytes: Int, records: Int, age: Option[FiniteDuration]): F[Unit] =
+          source.poll(topic, bytes, records, age)
+
+        override def count(name: String, topic: Topic): F[Unit] =
+          source.count(name, topic)
+
+        override def rebalance(name: String, topicPartition: TopicPartition): F[Unit] =
+          source.rebalance(name, topicPartition)
+
+        override def topics(latency: FiniteDuration): F[Unit] =
+          source.topics(latency)
+
+        override def exposeJavaMetrics[K, V](consumer: Consumer[F, K, V]): Resource[F, Unit] =
+          registry.register(consumer.clientMetrics)
+      }
+    }
 
   /**
     * Construct [[ConsumerMetrics]] that will expose Java Kafka client metrics.

--- a/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
+++ b/modules/metrics/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerMetricsOf.scala
@@ -3,12 +3,11 @@ package com.evolutiongaming.skafka.consumer
 import cats.effect.{Resource, Sync}
 import cats.effect.std.UUIDGen
 import com.evolutiongaming.catshelper.ToTry
-import com.evolutiongaming.skafka.{Topic, TopicPartition}
+import com.evolutiongaming.skafka.{ClientId, Topic, TopicPartition}
 import com.evolutiongaming.skafka.metrics.KafkaMetricsRegistry
 import io.prometheus.client.CollectorRegistry
 
 import scala.concurrent.duration.FiniteDuration
-import com.evolutiongaming.skafka.ClientId
 
 object ConsumerMetricsOf {
 

--- a/modules/metrics/src/main/scala/com/evolutiongaming/skafka/producer/ProducerMetricsOf.scala
+++ b/modules/metrics/src/main/scala/com/evolutiongaming/skafka/producer/ProducerMetricsOf.scala
@@ -28,34 +28,7 @@ object ProducerMetricsOf {
       registry <- KafkaMetricsRegistry.of(prometheus, prefix)
     } yield { (clientId: ClientId) =>
       val source = sourceOf(clientId)
-
-      new ProducerMetrics[F] {
-        override def initTransactions(latency: FiniteDuration): F[Unit] = source.initTransactions(latency)
-
-        override def beginTransaction: F[Unit] = source.beginTransaction
-
-        override def sendOffsetsToTransaction(latency: FiniteDuration): F[Unit] =
-          source.sendOffsetsToTransaction(latency)
-
-        override def commitTransaction(latency: FiniteDuration): F[Unit] = source.commitTransaction(latency)
-
-        override def abortTransaction(latency: FiniteDuration): F[Unit] = source.abortTransaction(latency)
-
-        override def send(topic: Topic, latency: FiniteDuration, bytes: Int): F[Unit] =
-          source.send(topic, latency, bytes)
-
-        override def block(topic: Topic, latency: FiniteDuration): F[Unit] = source.block(topic, latency)
-
-        override def failure(topic: Topic, latency: FiniteDuration): F[Unit] = source.failure(topic, latency)
-
-        override def partitions(topic: Topic, latency: FiniteDuration): F[Unit] = source.partitions(topic, latency)
-
-        override def flush(latency: FiniteDuration): F[Unit] = source.flush(latency)
-
-        override def exposeJavaMetrics(producer: Producer[F]): Resource[F, Unit] =
-          registry.register(producer.clientMetrics)
-
-      }
+      producerMetricsOf(source, registry)
     }
 
   /**
@@ -73,7 +46,13 @@ object ProducerMetricsOf {
   ): Resource[F, ProducerMetrics[F]] =
     for {
       registry <- KafkaMetricsRegistry.of(prometheus, prefix)
-    } yield new ProducerMetrics[F] {
+    } yield producerMetricsOf(source, registry)
+
+  private def producerMetricsOf[F[_]](
+    source: ProducerMetrics[F],
+    registry: KafkaMetricsRegistry[F],
+  ): ProducerMetrics[F] =
+    new ProducerMetrics[F] {
       override def initTransactions(latency: FiniteDuration): F[Unit] = source.initTransactions(latency)
 
       override def beginTransaction: F[Unit] = source.beginTransaction

--- a/modules/metrics/src/main/scala/com/evolutiongaming/skafka/producer/ProducerMetricsOf.scala
+++ b/modules/metrics/src/main/scala/com/evolutiongaming/skafka/producer/ProducerMetricsOf.scala
@@ -3,13 +3,60 @@ package com.evolutiongaming.skafka.producer
 import cats.effect.{Resource, Sync}
 import cats.effect.std.UUIDGen
 import com.evolutiongaming.catshelper.ToTry
-import com.evolutiongaming.skafka.Topic
+import com.evolutiongaming.skafka.{ClientId, Topic}
 import com.evolutiongaming.skafka.metrics.KafkaMetricsRegistry
 import io.prometheus.client.CollectorRegistry
 
 import scala.concurrent.duration.FiniteDuration
 
 object ProducerMetricsOf {
+
+  /**
+    * Construct [[ProducerMetrics]] that will expose Java Kafka client metrics.
+    *
+    * @param sourceOf original [[ProducerMetrics]] factory
+    * @param prometheus instance of Prometheus registry
+    * @param prefix metric name prefix
+    * @return [[ProducerMetrics]] that exposes Java Kafka client metrics
+    */
+  def withJavaClientMetrics[F[_]: Sync: ToTry: UUIDGen](
+    sourceOf: ClientId => ProducerMetrics[F],
+    prometheus: CollectorRegistry,
+    prefix: Option[String],
+  ): Resource[F, ClientId => ProducerMetrics[F]] =
+    for {
+      registry <- KafkaMetricsRegistry.of(prometheus, prefix)
+    } yield { (clientId: ClientId) =>
+      val source = sourceOf(clientId)
+
+      new ProducerMetrics[F] {
+        override def initTransactions(latency: FiniteDuration): F[Unit] = source.initTransactions(latency)
+
+        override def beginTransaction: F[Unit] = source.beginTransaction
+
+        override def sendOffsetsToTransaction(latency: FiniteDuration): F[Unit] =
+          source.sendOffsetsToTransaction(latency)
+
+        override def commitTransaction(latency: FiniteDuration): F[Unit] = source.commitTransaction(latency)
+
+        override def abortTransaction(latency: FiniteDuration): F[Unit] = source.abortTransaction(latency)
+
+        override def send(topic: Topic, latency: FiniteDuration, bytes: Int): F[Unit] =
+          source.send(topic, latency, bytes)
+
+        override def block(topic: Topic, latency: FiniteDuration): F[Unit] = source.block(topic, latency)
+
+        override def failure(topic: Topic, latency: FiniteDuration): F[Unit] = source.failure(topic, latency)
+
+        override def partitions(topic: Topic, latency: FiniteDuration): F[Unit] = source.partitions(topic, latency)
+
+        override def flush(latency: FiniteDuration): F[Unit] = source.flush(latency)
+
+        override def exposeJavaMetrics(producer: Producer[F]): Resource[F, Unit] =
+          registry.register(producer.clientMetrics)
+
+      }
+    }
 
   /**
     * Construct [[ProducerMetrics]] that will expose Java Kafka client metrics.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "16.2.1-SNAPSHOT"
+ThisBuild / version := "16.3.0"


### PR DESCRIPTION
Make Java client metrics usable with `ProducerMetrics.of` & `ConsumerMetrics.Of` factories