### PR TITLE
fix cause of `StackOverflowException` when initializing `RebalanceListener` with thousands of topic-partitions

### DIFF
--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConverters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConverters.scala
@@ -75,7 +75,7 @@ object ConsumerConverters {
           // If we fail to register the listener, fail right now on the consumer thread.
           .get
           // Schedule the actual callback for async execution with `.toFuture`.
-          .traverse_(asyncListener => asyncListener)
+          .sequence_
           .toFuture
         ()
       }

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConverters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/consumer/ConsumerConverters.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.record.{TimestampType => TimestampTypeJ}
 import org.apache.kafka.common.{TopicPartition => TopicPartitionJ}
 
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 object ConsumerConverters {
 
@@ -54,22 +55,27 @@ object ConsumerConverters {
       def onPartitions(
         partitions: CollectionJ[TopicPartitionJ],
         call: Nes[TopicPartition] => F[Unit]
-      ) = {
-        serialListeners
-          .listener {
-            partitions
-              .asScala
-              .toList
-              .traverse { _.asScala[F] }
-              .flatMap { partitions =>
-                partitions
-                  .toSortedSet
-                  .toNes
-                  .foldMapM(call)
-              }
+      ): Unit = {
+        // The whole callback runs partly on the consumer thread, and partly asynchronously.
+        // First, on the consumer thread, we pre-process the partition list, and register
+        // our listener in `serialListeners`.
+        // Then, asynchronously, we execute the registered listener.
+        partitions.asScala
+          .toList
+          // Note: `traverse(_.asScala[F])` may cause StackOverflowError later, when executed
+          // synchronously with `.toTry`. Traversing into `Try` directly avoids this.
+          .traverse(_.asScala[Try])
+          .flatMap { topicPartitions =>
+            topicPartitions
+              .toSortedSet
+              .toNes
+              .traverse { partitions => serialListeners.listener(call(partitions)) }
+              .toTry
           }
-          .toTry
+          // If we fail to register the listener, fail right now on the consumer thread.
           .get
+          // Schedule the actual callback for async execution with `.toFuture`.
+          .traverse_(asyncListener => asyncListener)
           .toFuture
         ()
       }
@@ -101,20 +107,18 @@ object ConsumerConverters {
       ): Unit = {
         // If you're thinking about deriving ToTry timeout based on ConsumerConfig.maxPollInterval
         // please have a look on https://github.com/evolution-gaming/skafka/issues/125
-        val result = partitions
-          .asScala
+        partitions.asScala
           .toList
-          .traverse { _.asScala[F] }
-          .map { partitions =>
-            partitions
-              .toSortedSet
+          // Note: `traverse(_.asScala[F])` may cause StackOverflowError later, when executed
+          // synchronously with `.toTry`. Traversing into `Try` directly avoids this.
+          .traverse { _.asScala[Try] }
+          .flatMap { topicPartitions =>
+            topicPartitions.toSortedSet
               .toNes
+              .traverse_ { partitions => call(partitions).run(RebalanceConsumer(consumer)) }
           }
-          .toTry
-          .flatMap {
-            _.foldMapM { partitions => call(partitions).run(RebalanceConsumer(consumer)) }
-          }
-        result.fold(throw _, _ => ())
+          // If we fail to make a `call(..).run(..)`, fail right now on the consumer thread.
+          .get
       }
 
       new RebalanceListenerJ {


### PR DESCRIPTION
Subscribing to thousands of partition-topics is not a problem, but when `RebalanceListener1` is added, consumer fails to init with `StackOverflowException`, like:
<details>
  <summary>stack trace</summary>

```
// thousands of next line with increasing index
interpret:2105, SyncStep$ (cats.effect) [2]
interpret:2105, SyncStep$ (cats.effect) [1]
syncStep:1939, IO$$anon$2 (cats.effect)
syncStep:1935, IO$$anon$2 (cats.effect)
syncStep:1047, IO (cats.effect)
apply$$anonfun$1:44, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:-1, ToTry$$anon$4$$Lambda/0x0000007e01744318 (com.evolutiongaming.catshelper)
apply:217, Try$ (scala.util)
apply:50, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:38, ToTry$$anon$4 (com.evolutiongaming.catshelper)
toTry$extension:74, CatsHelper$OpsCatsHelper$ (com.evolutiongaming.catshelper)
com$evolutiongaming$skafka$consumer$ConsumerConverters$RebalanceListener1Ops$$$_$onPartitions$2:141, ConsumerConverters$RebalanceListener1Ops$ (com.evolutiongaming.skafka.consumer)
onPartitionsAssigned:151, ConsumerConverters$RebalanceListener1Ops$$anon$2 (com.evolutiongaming.skafka.consumer)
invokePartitionsAssigned:65, ConsumerRebalanceListenerInvoker (org.apache.kafka.clients.consumer.internals)
onJoinComplete:425, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
joinGroupIfNeeded:504, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
ensureActiveGroup:415, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
poll:511, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
updateAssignmentMetadataIfNeeded:657, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:616, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:596, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:874, KafkaConsumer (org.apache.kafka.clients.consumer)
poll$$anonfun$1:436, Consumer$$anon$4 (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$4$$Lambda/0x0000007e0162bc00 (com.evolutiongaming.skafka.consumer)
com$evolutiongaming$skafka$consumer$Consumer$$anon$2$$_$apply$$anonfun$1$$anonfun$1:282, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$2$$Lambda/0x0000007e01637d40 (com.evolutiongaming.skafka.consumer)
blocking$1$$anonfun$1:267, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$$Lambda/0x0000007e014d2648 (com.evolutiongaming.skafka.consumer)
runLoop:1004, IOFiber (cats.effect)
execR:1362, IOFiber (cats.effect)
run:112, IOFiber (cats.effect)
run:634, WorkerThread (cats.effect.unsafe)
interpret:2105, SyncStep$ (cats.effect) [2]
interpret:2105, SyncStep$ (cats.effect) [1]
syncStep:1939, IO$$anon$2 (cats.effect)
syncStep:1935, IO$$anon$2 (cats.effect)
syncStep:1047, IO (cats.effect)
apply$$anonfun$1:44, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:-1, ToTry$$anon$4$$Lambda/0x0000007e01744318 (com.evolutiongaming.catshelper)
apply:217, Try$ (scala.util)
apply:50, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:38, ToTry$$anon$4 (com.evolutiongaming.catshelper)
toTry$extension:74, CatsHelper$OpsCatsHelper$ (com.evolutiongaming.catshelper)
com$evolutiongaming$skafka$consumer$ConsumerConverters$RebalanceListener1Ops$$$_$onPartitions$2:141, ConsumerConverters$RebalanceListener1Ops$ (com.evolutiongaming.skafka.consumer)
onPartitionsAssigned:151, ConsumerConverters$RebalanceListener1Ops$$anon$2 (com.evolutiongaming.skafka.consumer)
invokePartitionsAssigned:65, ConsumerRebalanceListenerInvoker (org.apache.kafka.clients.consumer.internals)
onJoinComplete:425, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
joinGroupIfNeeded:504, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
ensureActiveGroup:415, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
poll:511, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
updateAssignmentMetadataIfNeeded:657, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:616, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:596, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:874, KafkaConsumer (org.apache.kafka.clients.consumer)
poll$$anonfun$1:436, Consumer$$anon$4 (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$4$$Lambda/0x0000007e0162bc00 (com.evolutiongaming.skafka.consumer)
com$evolutiongaming$skafka$consumer$Consumer$$anon$2$$_$apply$$anonfun$1$$anonfun$1:282, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$2$$Lambda/0x0000007e01637d40 (com.evolutiongaming.skafka.consumer)
blocking$1$$anonfun$1:267, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$$Lambda/0x0000007e014d2648 (com.evolutiongaming.skafka.consumer)
runLoop:1004, IOFiber (cats.effect)
execR:1362, IOFiber (cats.effect)
run:112, IOFiber (cats.effect)
run:634, WorkerThread (cats.effect.unsafe)interpret:2105, SyncStep$ (cats.effect) [2]
interpret:2105, SyncStep$ (cats.effect) [1]
syncStep:1939, IO$$anon$2 (cats.effect)
syncStep:1935, IO$$anon$2 (cats.effect)
syncStep:1047, IO (cats.effect)
apply$$anonfun$1:44, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:-1, ToTry$$anon$4$$Lambda/0x0000007e01744318 (com.evolutiongaming.catshelper)
apply:217, Try$ (scala.util)
apply:50, ToTry$$anon$4 (com.evolutiongaming.catshelper)
apply:38, ToTry$$anon$4 (com.evolutiongaming.catshelper)
toTry$extension:74, CatsHelper$OpsCatsHelper$ (com.evolutiongaming.catshelper)
com$evolutiongaming$skafka$consumer$ConsumerConverters$RebalanceListener1Ops$$$_$onPartitions$2:141, ConsumerConverters$RebalanceListener1Ops$ (com.evolutiongaming.skafka.consumer)
onPartitionsAssigned:151, ConsumerConverters$RebalanceListener1Ops$$anon$2 (com.evolutiongaming.skafka.consumer)
invokePartitionsAssigned:65, ConsumerRebalanceListenerInvoker (org.apache.kafka.clients.consumer.internals)
onJoinComplete:425, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
joinGroupIfNeeded:504, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
ensureActiveGroup:415, AbstractCoordinator (org.apache.kafka.clients.consumer.internals)
poll:511, ConsumerCoordinator (org.apache.kafka.clients.consumer.internals)
updateAssignmentMetadataIfNeeded:657, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:616, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:596, ClassicKafkaConsumer (org.apache.kafka.clients.consumer.internals)
poll:874, KafkaConsumer (org.apache.kafka.clients.consumer)
poll$$anonfun$1:436, Consumer$$anon$4 (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$4$$Lambda/0x0000007e0162bc00 (com.evolutiongaming.skafka.consumer)
com$evolutiongaming$skafka$consumer$Consumer$$anon$2$$_$apply$$anonfun$1$$anonfun$1:282, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$anon$2$$Lambda/0x0000007e01637d40 (com.evolutiongaming.skafka.consumer)
blocking$1$$anonfun$1:267, Consumer$ (com.evolutiongaming.skafka.consumer)
apply:-1, Consumer$$$Lambda/0x0000007e014d2648 (com.evolutiongaming.skafka.consumer)
runLoop:1004, IOFiber (cats.effect)
execR:1362, IOFiber (cats.effect)
run:112, IOFiber (cats.effect)
run:634, WorkerThread (cats.effect.unsafe)
``` 
</details>

This PR addresses the cause in `skafka` code.

Other cause could be due to way how large `.flatMap` cascades are executed on `IO` in `cats-helper` project:
* https://github.com/evolution-gaming/cats-helper/blob/89ef71efd006802cf0b017563c964f43805405b1/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala#L44
* https://github.com/evolution-gaming/cats-helper/blob/89ef71efd006802cf0b017563c964f43805405b1/core/src/main/scala/com/evolutiongaming/catshelper/ToFuture.scala#L31

In `cats-helper` we do `fa.syncStep(Int.MaxValue).unsafeRunSync()`. Possibly, we could reduce the `limit` in `syncStep` to smaller value, like `1000`, but currently we use value, as it was in Cats Effect 3.4.0.