### PR TITLE
update kafka-clients from 4.2.0 to 4.3.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val discipline             = "org.typelevel"          %% "discipline-scalatest"       % "2.3.0"
 
   object Kafka {
-    private val version = "4.2.0"
+    private val version = "4.3.0"
     val clients         = "org.apache.kafka" % "kafka-clients" % version
   }
 

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
@@ -7,7 +7,7 @@ import com.evolutiongaming.catshelper.{ApplicativeThrowable, MonadThrowable}
 import com.evolutiongaming.skafka.Converters.*
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
 import org.apache.kafka.clients.producer.{ProducerRecord as ProducerRecordJ, RecordMetadata as RecordMetadataJ}
-import org.apache.kafka.common.record.RecordBatch
+import org.apache.kafka.common.record.internal.RecordBatch
 import org.apache.kafka.common.requests.ProduceResponse
 
 import scala.jdk.CollectionConverters.*

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
@@ -6,8 +6,8 @@ import cats.implicits.*
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, MonadThrowable}
 import com.evolutiongaming.skafka.Converters.*
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import org.apache.kafka.clients.consumer.ConsumerRecord.NO_TIMESTAMP
 import org.apache.kafka.clients.producer.{ProducerRecord as ProducerRecordJ, RecordMetadata as RecordMetadataJ}
-import org.apache.kafka.common.record.internal.RecordBatch
 import org.apache.kafka.common.requests.ProduceResponse
 
 import scala.jdk.CollectionConverters.*
@@ -56,7 +56,7 @@ object ProducerConverters {
       } yield {
         RecordMetadata(
           topicPartition      = TopicPartition(self.topic, partition),
-          timestamp           = (self.timestamp noneIf RecordBatch.NO_TIMESTAMP).map(Instant.ofEpochMilli),
+          timestamp           = (self.timestamp noneIf ConsumerRecord.NO_TIMESTAMP).map(Instant.ofEpochMilli),
           offset              = offset,
           keySerializedSize   = self.serializedKeySize noneIf -1,
           valueSerializedSize = self.serializedValueSize noneIf -1
@@ -72,7 +72,7 @@ object ProducerConverters {
         self.topicPartition.asJava,
         0,
         self.offset.fold(ProduceResponse.INVALID_OFFSET.toInt) { _.value.toInt },
-        self.timestamp.fold(RecordBatch.NO_TIMESTAMP)(_.toEpochMilli),
+        self.timestamp.fold(ConsumerRecord.NO_TIMESTAMP)(_.toEpochMilli),
         self.keySerializedSize getOrElse -1,
         self.valueSerializedSize getOrElse -1
       )

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerConverters.scala
@@ -6,7 +6,7 @@ import cats.implicits.*
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, MonadThrowable}
 import com.evolutiongaming.skafka.Converters.*
 import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
-import org.apache.kafka.clients.consumer.ConsumerRecord.NO_TIMESTAMP
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.{ProducerRecord as ProducerRecordJ, RecordMetadata as RecordMetadataJ}
 import org.apache.kafka.common.requests.ProduceResponse
 


### PR DESCRIPTION
in [KAFKA-20128](https://issues.apache.org/jira/browse/KAFKA-20128) Apache moved `RecordBatch` to `internal` subpackage with comment:
> Move all non-public classes to an "internal" subpackage

see:
* https://github.com/apache/kafka/commit/0166a0342d82b3b9b89397b15304e974507c7eb8#diff-0b2ee01204db07f80793670fabc5d0e42ba6970aacc96249c9bb57057222ddccR17
* https://github.com/apache/kafka/pull/21412