### PR TITLE
Add Producer.sendOffsetsToTransaction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,9 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
 //  ProblemFilters.exclude[ReversedMissingMethodProblem](
 //    "com.evolutiongaming.skafka.consumer.Consumer.clientInstanceId"
 //  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "com.evolutiongaming.skafka.producer.Producer.sendOffsetsToTransaction"
+  ),
 )
 ThisBuild / versionPolicyIgnored ++= Seq(
   // add libraries, that are known to be binary compatible, here, like:

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -277,7 +277,15 @@ object Producer {
       def sendOffsetsToTransaction(
         offsets: Nem[TopicPartition, OffsetAndMetadata],
         consumerGroupMetadata: ConsumerGroupMetadata
-      ): F[Unit] = producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata)
+      ): F[Unit] = {
+        for {
+          d <- MeasureDuration[F].start
+          r <- producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata).attempt
+          d <- d
+          _ <- metrics.sendOffsetsToTransaction(d)
+          r <- r.liftTo[F]
+        } yield r
+      }
 
       def send[K, V](
         record: ProducerRecord[K, V]

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/Producer.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.skafka
 package producer
 
+import cats.data.NonEmptyMap as Nem
 import cats.effect.{Async, Deferred, Resource, Sync}
 import cats.effect.implicits.*
 import cats.implicits.*
@@ -8,6 +9,8 @@ import cats.{Applicative, Functor, Monad, MonadError, MonadThrow, ~>}
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{Log, MeasureDuration, ToTry}
 import com.evolutiongaming.skafka.Converters.*
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
+import com.evolutiongaming.skafka.consumer.ConsumerConverters.*
 import com.evolutiongaming.skafka.producer.ProducerConverters.*
 import org.apache.kafka.clients.producer.{
   Callback,
@@ -32,6 +35,15 @@ trait Producer[F[_]] {
   def commitTransaction: F[Unit]
 
   def abortTransaction: F[Unit]
+
+  /** Sends consumed offsets to the consumer group coordinator as part of the current transaction, fencing zombie
+    * writers by the consumer group generation (KIP-447). The `consumerGroupMetadata` must come from the input
+    * consumer's `groupMetadata()`; offsets become committed only if the transaction commits.
+    */
+  def sendOffsetsToTransaction(
+    offsets: Nem[TopicPartition, OffsetAndMetadata],
+    consumerGroupMetadata: ConsumerGroupMetadata
+  ): F[Unit]
 
   /** @return
     *   Outer F[_] is about sending event (including batching if required), inner F[_] is about waiting and getting the
@@ -69,6 +81,11 @@ object Producer {
       def commitTransaction: F[Unit] = empty
 
       def abortTransaction: F[Unit] = empty
+
+      def sendOffsetsToTransaction(
+        offsets: Nem[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata
+      ): F[Unit] = empty
 
       def send[K, V](
         record: ProducerRecord[K, V]
@@ -119,6 +136,13 @@ object Producer {
 
         def abortTransaction: F[Unit] = {
           blocking { producer.abortTransaction() }
+        }
+
+        def sendOffsetsToTransaction(
+          offsets: Nem[TopicPartition, OffsetAndMetadata],
+          consumerGroupMetadata: ConsumerGroupMetadata
+        ): F[Unit] = {
+          blocking { producer.sendOffsetsToTransaction(asOffsetsAndMetadataJ(offsets), consumerGroupMetadata.asJava) }
         }
 
         def send[K, V](
@@ -250,6 +274,11 @@ object Producer {
         } yield r
       }
 
+      def sendOffsetsToTransaction(
+        offsets: Nem[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata
+      ): F[Unit] = producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata)
+
       def send[K, V](
         record: ProducerRecord[K, V]
       )(implicit toBytesK: ToBytes[F, K], toBytesV: ToBytes[F, V]): F[F[RecordMetadata]] = {
@@ -344,6 +373,11 @@ object Producer {
       def commitTransaction: G[Unit] = fg(self.commitTransaction)
 
       def abortTransaction: G[Unit] = fg(self.abortTransaction)
+
+      def sendOffsetsToTransaction(
+        offsets: Nem[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata
+      ): G[Unit] = fg(self.sendOffsetsToTransaction(offsets, consumerGroupMetadata))
 
       def send[K, V](
         record: ProducerRecord[K, V]

--- a/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
+++ b/skafka/src/main/scala/com/evolutiongaming/skafka/producer/ProducerLogging.scala
@@ -1,9 +1,11 @@
 package com.evolutiongaming.skafka.producer
 
+import cats.data.NonEmptyMap as Nem
 import cats.implicits.*
 import cats.MonadThrow
 import com.evolutiongaming.catshelper.{Log, MeasureDuration}
-import com.evolutiongaming.skafka.{ClientMetric, PartitionInfo, ToBytes, Topic}
+import com.evolutiongaming.skafka.{ClientMetric, OffsetAndMetadata, PartitionInfo, ToBytes, Topic, TopicPartition}
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.errors.RecordTooLargeException
 
@@ -29,6 +31,11 @@ object ProducerLogging {
       def commitTransaction: F[Unit] = producer.commitTransaction
 
       def abortTransaction: F[Unit] = producer.abortTransaction
+
+      def sendOffsetsToTransaction(
+        offsets: Nem[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata
+      ): F[Unit] = producer.sendOffsetsToTransaction(offsets, consumerGroupMetadata)
 
       def send[K, V](
         record: ProducerRecord[K, V]

--- a/skafka/src/test/scala/com/evolutiongaming/skafka/producer/ProducerSpec.scala
+++ b/skafka/src/test/scala/com/evolutiongaming/skafka/producer/ProducerSpec.scala
@@ -3,13 +3,15 @@ package com.evolutiongaming.skafka.producer
 import java.util
 import java.util.concurrent.{CompletableFuture, Future as FutureJ}
 import cats.arrow.FunctionK
+import cats.data.NonEmptyMap as Nem
 import cats.effect.IO
 import cats.implicits.*
 import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.skafka.IOMatchers.*
+import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.ProducerConverters.*
-import com.evolutiongaming.skafka.{Bytes, Partition, PartitionInfo, TopicPartition}
+import com.evolutiongaming.skafka.{Bytes, OffsetAndMetadata, Partition, PartitionInfo, TopicPartition}
 import com.evolutiongaming.skafka.IOSuite.*
 import org.apache.kafka.clients.consumer.{
   ConsumerGroupMetadata as ConsumerGroupMetadataJ,
@@ -58,6 +60,14 @@ class ProducerSpec extends AnyWordSpec with Matchers {
     "proxy abortTransaction" in new Scope {
       verify(producer.abortTransaction) { _ =>
         abortTransaction shouldEqual true
+      }
+    }
+
+    "proxy sendOffsetsToTransaction" in new Scope {
+      val offsets       = Nem.of(topicPartition -> OffsetAndMetadata())
+      val groupMetadata = ConsumerGroupMetadata("group", 1, "member", None)
+      verify(producer.sendOffsetsToTransaction(offsets, groupMetadata)) { _ =>
+        sendOffsetsToTransaction1.map(_.groupId) shouldEqual Some("group")
       }
     }
 
@@ -114,6 +124,11 @@ class ProducerSpec extends AnyWordSpec with Matchers {
 
     "abortTransaction" in new Scope {
       verify(empty.abortTransaction) { _ => }
+    }
+
+    "sendOffsetsToTransaction" in new Scope {
+      val offsets = Nem.of(topicPartition -> OffsetAndMetadata())
+      verify(empty.sendOffsetsToTransaction(offsets, ConsumerGroupMetadata("group", 1, "member", None))) { _ => }
     }
 
     "send" in {

--- a/skafka/src/test/scala/com/evolutiongaming/skafka/producer/ProducerSpec.scala
+++ b/skafka/src/test/scala/com/evolutiongaming/skafka/producer/ProducerSpec.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.implicits.*
 import com.evolutiongaming.catshelper.MeasureDuration
 import com.evolutiongaming.catshelper.CatsHelper.*
+import com.evolutiongaming.skafka.Converters.*
 import com.evolutiongaming.skafka.IOMatchers.*
 import com.evolutiongaming.skafka.consumer.ConsumerGroupMetadata
 import com.evolutiongaming.skafka.producer.ProducerConverters.*
@@ -67,7 +68,8 @@ class ProducerSpec extends AnyWordSpec with Matchers {
       val offsets       = Nem.of(topicPartition -> OffsetAndMetadata())
       val groupMetadata = ConsumerGroupMetadata("group", 1, "member", None)
       verify(producer.sendOffsetsToTransaction(offsets, groupMetadata)) { _ =>
-        sendOffsetsToTransaction1.map(_.groupId) shouldEqual Some("group")
+        sentOffsets.map(_.asScala.toMap) shouldEqual Some(Map(topicPartition.asJava -> OffsetAndMetadata().asJava))
+        sentGroupMetadata.map(_.groupId) shouldEqual Some("group")
       }
     }
 
@@ -146,15 +148,15 @@ class ProducerSpec extends AnyWordSpec with Matchers {
   }
 
   private trait Scope {
-    var flushCalled                                               = false
-    var commitTransaction                                         = false
-    var beginTransaction                                          = false
-    var initTransactions                                          = false
-    var abortTransaction                                          = false
-    var partitionsFor                                             = ""
-    var sendOffsetsToTransaction                                  = ""
-    var sendOffsetsToTransaction1: Option[ConsumerGroupMetadataJ] = none[ConsumerGroupMetadataJ]
-    val completableFuture: CompletableFuture[RecordMetadataJ]     = CompletableFuture.completedFuture(metadata.asJava)
+    var flushCalled                                                        = false
+    var commitTransaction                                                  = false
+    var beginTransaction                                                   = false
+    var initTransactions                                                   = false
+    var abortTransaction                                                   = false
+    var partitionsFor                                                      = ""
+    var sentOffsets: Option[util.Map[TopicPartitionJ, OffsetAndMetadataJ]] = none
+    var sentGroupMetadata: Option[ConsumerGroupMetadataJ]                  = none
+    val completableFuture: CompletableFuture[RecordMetadataJ] = CompletableFuture.completedFuture(metadata.asJava)
 
     val jProducer: ProducerJ[Bytes, Bytes] = new ProducerJ[Bytes, Bytes] {
 
@@ -166,7 +168,8 @@ class ProducerSpec extends AnyWordSpec with Matchers {
         offsets: util.Map[TopicPartitionJ, OffsetAndMetadataJ],
         groupMetadata: ConsumerGroupMetadataJ
       ): Unit = {
-        Scope.this.sendOffsetsToTransaction1 = groupMetadata.some
+        Scope.this.sentOffsets       = offsets.some
+        Scope.this.sentGroupMetadata = groupMetadata.some
       }
 
       def flush(): Unit = flushCalled = true


### PR DESCRIPTION
Adds `Producer.sendOffsetsToTransaction`, exposing the Kafka producer API for
sending consumed offsets to the consumer group coordinator within a transaction.
This enables read-process-write (consume-transform-produce) flows where offset
commits and produced records are atomic, with zombie writers fenced by the
consumer group generation (KIP-447).

## Changes

- New `sendOffsetsToTransaction(offsets, consumerGroupMetadata)` on the `Producer[F]`
  trait, threaded through all wrappers (`empty`, `fromProducerJ2`, `withMetrics`,
  `mapK`) and `ProducerLogging`. Reuses the existing `asOffsetsAndMetadataJ` and
  `ConsumerGroupMetadata.asJava` converters.
- The `WithMetrics` wrapper records `ProducerMetrics.sendOffsetsToTransaction`
  (the metric already existed but was never invoked).
- `mimaBinaryIssueFilters` entry for the new trait method so `versionPolicyCheck`
  passes (same approach as `clientInstanceId` in v19.1.0).
- `ProducerSpec` coverage for the proxy and empty producer.

## Notes

- `consumerGroupMetadata` must come from the consuming consumer's `groupMetadata()`;
  offsets become committed only if the transaction commits.
- The mima filter follows the convention of being removed in the post-release
  cleanup commit.
