### PR TITLE
Adopt shared Scala CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@dde27b9bd793d41d5aacf8fb74403c9de5da1146 # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,4 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - 2.13.18
-          - 3.3.8
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: coursier/cache-action@v8
-
-      - name: setup Java 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - name: check code ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean check
-
-      - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
-
-      - name: test coverage
-        if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
-
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.1.0")


### PR DESCRIPTION
Replaces the hand-written ci.yml with a call to the shared workflow, so tests, coverage, binary compatibility, formatting and scaladoc are configured centrally. Drops the now-unused sbt-coveralls plugin, which has no sbt 2 build.

Checks now run as explicit sbt tasks rather than through the `check` alias, and checkout is unshallow so versionPolicyCheck has a previous version to compare against.

Part of evolution-gaming/scala-github-actions#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to use the latest shared Scala build process.
  * Replaced the previous code coverage integration with an updated coverage tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->