### PR TITLE
Update smetrics to 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,12 @@ import com.typesafe.tools.mima.core._
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
+ThisBuild / versionPolicyIgnored ++= Seq(
+  // add libraries here that are known to be binary compatible, like:
+  "com.evolutiongaming" %% "smetrics",
+  "com.evolutiongaming" %% "smetrics-prometheus",
+  "com.evolutiongaming" %% "smetrics-prometheus-v1",
+)
 
 def crossSettings[T](scalaVersion: String, if3: List[T], if2: List[T]): List[T] =
   CrossVersion.partialVersion(scalaVersion) match {

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,10 @@ lazy val commonSettings = Seq(
   ),
   scalacOptsFailOnWarn := Some(false),
   publishTo := Some(Resolver.evolutionReleases),
+  versionPolicyIgnored ++= Seq(
+    // add libraries here that are known to be binary compatible, like:
+    "com.evolutiongaming" %% "smetrics",
+  ),
 )
 
 ThisBuild / mimaBinaryIssueFilters ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
   }
 
   object Smetrics {
-    private val version          = "2.5.0"
+    private val version          = "3.0.0"
     val smetrics                 = "com.evolutiongaming" %% "smetrics"               % version
     val `smetrics-prometheus`    = "com.evolutiongaming" %% "smetrics-prometheus"    % version
     val `smetrics-prometheus-v1` = "com.evolutiongaming" %% "smetrics-prometheus-v1" % version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Smetrics dependency to version 3.0.0.
  * Adjusted compatibility checks to recognize the updated Smetrics version as binary-compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->